### PR TITLE
Add Lassen OSU data and batch script

### DIFF
--- a/google/kubecon/hpc/README.md
+++ b/google/kubecon/hpc/README.md
@@ -1,0 +1,6 @@
+# OSU Benchmarks on Lassen at LLNL
+
+This is the start to an experimental setup for running OSU Benchmark experiments for Kubecon America, 2023.
+We will be using LSF, which is the scheduler and resource manager on [Lassen](https://hpc.llnl.gov/hardware/compute-platforms/lassen).
+
+ - [run1](run1): Run OSU to compare against GKE and Compute Engine network. The batch script to run the tests is included.

--- a/google/kubecon/hpc/lassen-run1/jsrun_osu.sh
+++ b/google/kubecon/hpc/lassen-run1/jsrun_osu.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+### LSF syntax
+#BSUB -nnodes 128                   #number of nodes
+#BSUB -W 120                    #walltime in minutes
+#BSUB -G ice4hpc                   #account
+#BSUB -e osu_errors.txt             #stderr
+#BSUB -o osu_output.txt             #stdout
+#BSUB -J kubecon_osu_128                    #name of job
+#BSUB -q pbatch                   #queue to use
+
+### Shell scripting
+date; hostname
+echo -n 'JobID is '; echo $LSB_JOBID
+echo "Hosts: $LSB_HOSTS"
+cd /g/g12/milroy1/kubecon-2023
+
+for nnodes in {2..7}
+do
+    echo "Number of nodes: " $(( 2**$nnodes )) > /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+    for i in {1..20}
+    do
+        echo "==============" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        echo "Start run ${i} of 20" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        #echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_ibarrier" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        #{ time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_ibarrier ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "End run ${i} of 20\n" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+    done
+done
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_128_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_128_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  128
+==============
+Start run 1 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     201.40      201400361.89
+2                     406.71      203355161.58
+4                     821.36      205339632.55
+8                    1629.44      203680369.01
+16                   3155.17      197198396.22
+32                   6191.46      193483078.02
+64                  12443.70      194432748.63
+128                 23971.47      187277134.04
+256                 43063.96      168218595.47
+512                 80869.17      157947606.59
+1024               144471.76      141085698.54
+2048               232516.40      113533397.14
+4096               354699.51       86596560.66
+8192               479908.95       58582634.91
+16384              552319.69       33710918.67
+32768              645976.47       19713637.28
+65536              702598.94       10720808.99
+131072             537736.84        4102606.47
+262144             537792.84        2051516.88
+524288             538463.60        1027037.81
+1048576            539991.09         514975.64
+2097152            537702.91         256396.73
+4194304            536709.82         127961.59
+real 12.81
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.16
+65536                  12.03
+131072                 17.06
+262144                 26.02
+524288                 44.57
+1048576                82.04
+2097152               157.47
+4194304               308.37
+real 2.49
+user 0.22
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.59
+user 0.18
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.48
+8                      13.09
+16                     13.19
+32                     13.13
+64                     13.51
+128                    14.00
+256                    15.67
+512                    16.34
+1024                   17.99
+2048                   23.47
+4096                   28.37
+8192                   39.38
+16384                  63.53
+32768                  72.33
+65536                 109.26
+131072                136.96
+262144                226.13
+524288                281.10
+1048576               438.00
+real 2.39
+user 0.20
+sys 0.04
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     202.86      202856231.59
+2                     408.79      204397337.25
+4                     819.29      204822632.90
+8                    1622.22      202776894.92
+16                   3138.12      196132605.94
+32                   6233.82      194806800.74
+64                  12396.51      193695532.00
+128                 23997.05      187476942.99
+256                 42879.09      167496447.45
+512                 80629.58      157479648.95
+1024               143013.40      139661518.58
+2048               231877.85      113221608.08
+4096               354619.59       86577048.71
+8192               478994.50       58471008.81
+16384              552901.34       33746419.39
+32768              646096.50       19717300.32
+65536              702807.98       10723998.73
+131072             537202.74        4098531.62
+262144             537505.33        2050420.12
+524288             538412.07        1026939.52
+1048576            539607.57         514609.88
+2097152            537523.39         256311.13
+4194304            536572.35         127928.82
+real 11.04
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.77
+32768                   9.16
+65536                  12.04
+131072                 17.05
+262144                 25.98
+524288                 44.56
+1048576                82.02
+2097152               157.53
+4194304               308.42
+real 2.45
+user 0.22
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.31
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.66
+8                      13.24
+16                     13.16
+32                     13.06
+64                     13.65
+128                    14.02
+256                    15.71
+512                    16.35
+1024                   17.92
+2048                   23.56
+4096                   28.57
+8192                   39.42
+16384                  63.13
+32768                  72.56
+65536                 109.69
+131072                136.37
+262144                223.68
+524288                281.32
+1048576               438.04
+real 2.05
+user 0.16
+sys 0.07
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     202.43      202429349.88
+2                     410.24      205118035.51
+4                     813.91      203478407.74
+8                    1616.43      202054084.99
+16                   3146.97      196685730.20
+32                   6204.94      193904414.02
+64                  12342.21      192847050.54
+128                 24003.89      187530417.61
+256                 42812.16      167235004.38
+512                 80341.51      156917009.83
+1024               143547.19      140182805.77
+2048               232068.57      113314729.73
+4096               354952.93       86658431.01
+8192               479334.31       58512488.54
+16384              554056.00       33816894.56
+32768              645974.97       19713591.74
+65536              703852.02       10739929.49
+131072             537336.00        4099548.36
+262144             537613.38        2050832.29
+524288             538201.48        1026537.86
+1048576            539707.68         514705.35
+2097152            537476.43         256288.73
+4194304            536927.11         128013.40
+real 10.95
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.41
+8192                    4.90
+16384                   6.78
+32768                   9.14
+65536                  12.00
+131072                 16.99
+262144                 26.00
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.40
+real 2.41
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.59
+user 0.21
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.38
+8                      13.12
+16                     13.20
+32                     13.29
+64                     13.53
+128                    14.04
+256                    15.60
+512                    16.23
+1024                   17.99
+2048                   23.49
+4096                   28.39
+8192                   39.42
+16384                  63.19
+32768                  71.19
+65536                 108.79
+131072                136.31
+262144                224.45
+524288                280.93
+1048576               438.58
+real 2.32
+user 0.18
+sys 0.05
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.31      200311421.66
+2                     406.69      203345772.71
+4                     818.86      204714940.94
+8                    1623.32      202914920.39
+16                   3121.04      195065082.02
+32                   6206.70      193959322.53
+64                  12451.81      194559552.51
+128                 24066.96      188023163.21
+256                 42825.33      167286435.14
+512                 80699.67      157616542.35
+1024               143732.35      140363622.66
+2048               232620.92      113584431.83
+4096               355929.02       86896732.27
+8192               482140.97       58855098.78
+16384              553480.19       33781749.77
+32768              646099.42       19717389.54
+65536              703539.80       10735165.41
+131072             536990.00        4096908.57
+262144             537666.57        2051035.18
+524288             538425.57        1026965.28
+1048576            539682.26         514681.11
+2097152            537511.17         256305.30
+4194304            536727.26         127965.75
+real 11.25
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.14
+1                       1.12
+2                       1.12
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.20
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.39
+8192                    4.89
+16384                   6.78
+32768                   9.17
+65536                  12.08
+131072                 16.98
+262144                 26.01
+524288                 44.56
+1048576                82.03
+2097152               157.47
+4194304               308.40
+real 2.45
+user 0.17
+sys 0.07
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.59
+user 0.22
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.45
+8                      13.16
+16                     13.18
+32                     13.20
+64                     13.51
+128                    14.39
+256                    15.61
+512                    16.27
+1024                   17.97
+2048                   23.54
+4096                   28.38
+8192                   39.36
+16384                  63.33
+32768                  71.39
+65536                 108.84
+131072                136.06
+262144                223.35
+524288                281.66
+1048576               437.67
+real 2.01
+user 0.18
+sys 0.06
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.91      200906630.41
+2                     405.99      202994365.12
+4                     816.11      204026840.29
+8                    1630.09      203760718.46
+16                   3121.57      195098251.69
+32                   6182.39      193199618.69
+64                  12320.90      192514042.57
+128                 23934.81      186990723.05
+256                 43079.49      168279274.57
+512                 80907.02      158021521.17
+1024               144274.91      140893469.61
+2048               231637.42      113104210.78
+4096               356184.12       86959013.98
+8192               481658.72       58796230.44
+16384              552644.95       33730770.64
+32768              645727.25       19706031.81
+65536              699734.40       10677099.64
+131072             536545.12        4093514.38
+262144             537269.25        2049519.54
+524288             538376.04        1026870.81
+1048576            539414.51         514425.76
+2097152            538046.07         256560.36
+4194304            537105.92         128056.03
+real 10.92
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.44
+8192                    4.94
+16384                   6.77
+32768                   9.20
+65536                  12.08
+131072                 17.08
+262144                 25.96
+524288                 44.54
+1048576                82.06
+2097152               157.52
+4194304               308.38
+real 2.81
+user 0.20
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.27
+user 0.21
+sys 0.03
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.41
+8                      13.18
+16                     13.41
+32                     13.11
+64                     13.53
+128                    14.15
+256                    15.57
+512                    16.30
+1024                   18.00
+2048                   23.46
+4096                   28.36
+8192                   39.41
+16384                  63.00
+32768                  71.28
+65536                 109.05
+131072                136.65
+262144                223.90
+524288                284.58
+1048576               436.33
+real 2.31
+user 0.20
+sys 0.03
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.32      200317985.24
+2                     409.24      204618707.82
+4                     824.95      206238305.95
+8                    1630.92      203865277.70
+16                   3128.28      195517419.48
+32                   6206.16      193942516.12
+64                  12391.84      193622557.03
+128                 23969.28      187260010.25
+256                 42602.22      166414904.53
+512                 80500.46      157227453.54
+1024               143955.03      140581084.50
+2048               231058.03      112821303.84
+4096               356472.01       87029298.66
+8192               482642.93       58916373.13
+16384              552284.51       33708771.36
+32768              645685.13       19704746.31
+65536              702684.46       10722113.96
+131072             537620.46        4101718.58
+262144             540122.22        2060402.77
+524288             540191.21        1030332.97
+1048576            541720.84         516625.25
+2097152            537958.69         256518.69
+4194304            537185.38         128074.97
+real 11.01
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.81
+32768                   9.17
+65536                  12.05
+131072                 17.06
+262144                 25.98
+524288                 44.57
+1048576                82.07
+2097152               157.50
+4194304               308.36
+real 2.44
+user 0.16
+sys 0.07
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.58
+user 0.20
+sys 0.03
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.55
+8                      13.34
+16                     13.44
+32                     13.31
+64                     13.48
+128                    14.22
+256                    15.62
+512                    16.46
+1024                   21.92
+2048                   32.20
+4096                   33.85
+8192                   39.93
+16384                  63.49
+32768                  72.99
+65536                 108.75
+131072                137.24
+262144                225.66
+524288                281.54
+1048576               438.30
+real 2.09
+user 0.21
+sys 0.03
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     201.07      201072912.49
+2                     408.51      204256371.67
+4                     818.63      204656331.26
+8                    1613.18      201647245.32
+16                   3145.50      196593687.98
+32                   6222.88      194464872.65
+64                  12459.62      194681617.61
+128                 23810.61      186020403.20
+256                 42813.80      167241422.96
+512                 80603.86      157429411.40
+1024               143716.44      140348087.93
+2048               231016.16      112800859.67
+4096               355332.58       86751117.69
+8192               479491.99       58531736.53
+16384              553086.20       33757702.93
+32768              644179.34       19658793.23
+65536              702462.81       10718731.79
+131072             537720.19        4102479.46
+262144             537577.22        2050694.36
+524288             538222.54        1026578.02
+1048576            539584.65         514588.02
+2097152            537952.61         256515.79
+4194304            537673.78         128191.42
+real 10.98
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.41
+8192                    4.90
+16384                   6.78
+32768                   9.17
+65536                  12.02
+131072                 17.02
+262144                 25.97
+524288                 44.55
+1048576                82.02
+2097152               157.49
+4194304               308.38
+real 2.45
+user 0.20
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.25
+user 0.16
+sys 0.08
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.51
+8                      13.13
+16                     13.22
+32                     13.23
+64                     13.66
+128                    14.28
+256                    15.58
+512                    16.31
+1024                   17.98
+2048                   28.86
+4096                   31.86
+8192                   39.38
+16384                  63.01
+32768                  71.21
+65536                 108.98
+131072                137.06
+262144                222.96
+524288                280.68
+1048576               437.60
+real 2.04
+user 0.19
+sys 0.04
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     199.21      199205996.80
+2                     407.16      203578731.19
+4                     812.05      203012978.26
+8                    1610.34      201292973.17
+16                   3107.64      194227700.68
+32                   6191.20      193474852.76
+64                  12306.84      192294420.79
+128                 23787.96      185843414.22
+256                 42790.81      167151607.65
+512                 80080.46      156407156.54
+1024               142896.65      139547513.10
+2048               231719.65      113144357.95
+4096               353778.41       86371682.91
+8192               478480.18       58408224.72
+16384              552524.14       33723397.34
+32768              645702.71       19705282.86
+65536              702351.43       10717032.25
+131072             537592.93        4101508.53
+262144             537230.72        2049372.56
+524288             538512.90        1027131.84
+1048576            539590.79         514593.87
+2097152            537731.16         256410.20
+4194304            537043.96         128041.26
+real 11.30
+user 0.17
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.16
+65536                  12.00
+131072                 17.06
+262144                 25.97
+524288                 44.55
+1048576                82.03
+2097152               157.50
+4194304               308.37
+real 2.44
+user 0.20
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.54
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      15.35
+8                      13.15
+16                     13.22
+32                     13.19
+64                     15.86
+128                    14.00
+256                    15.81
+512                    16.20
+1024                   17.91
+2048                   23.42
+4096                   30.18
+8192                   39.88
+16384                  63.20
+32768                  75.09
+65536                 109.00
+131072                136.18
+262144                223.12
+524288                281.29
+1048576               444.77
+real 2.05
+user 0.18
+sys 0.06
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     201.86      201863690.75
+2                     408.37      204187234.11
+4                     815.16      203789915.28
+8                    1618.30      202287588.16
+16                   3151.67      196979234.95
+32                   6216.91      194278461.37
+64                  12377.39      193396656.26
+128                 23912.14      186813587.77
+256                 42798.27      167180739.28
+512                 79646.07      155558737.29
+1024               142204.67      138871748.41
+2048               231152.64      112867501.38
+4096               354424.51       86529422.33
+8192               481066.85       58723980.66
+16384              554206.81       33826099.33
+32768              645032.33       19684824.62
+65536              702435.51       10718315.27
+131072             539576.84        4116644.56
+262144             538838.83        2055507.03
+524288             538180.46        1026497.76
+1048576            539430.44         514440.96
+2097152            537661.59         256377.03
+4194304            537059.99         128045.08
+real 10.94
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.85
+32768                   9.16
+65536                  12.07
+131072                 17.05
+262144                 25.99
+524288                 44.58
+1048576                82.06
+2097152               157.50
+4194304               308.36
+real 2.76
+user 0.23
+sys 0.01
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.31
+user 0.19
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.36
+8                      13.19
+16                     13.34
+32                     13.22
+64                     13.73
+128                    14.01
+256                    15.56
+512                    16.21
+1024                   17.98
+2048                   23.84
+4096                   28.43
+8192                   39.43
+16384                  63.16
+32768                  71.25
+65536                 108.63
+131072                135.99
+262144                222.75
+524288                280.42
+1048576               438.74
+real 2.55
+user 0.20
+sys 0.04
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     199.25      199246404.95
+2                     409.25      204623307.77
+4                     820.43      205107147.95
+8                    1623.05      202881250.57
+16                   3103.16      193947475.08
+32                   6211.04      194094982.39
+64                  12434.58      194290349.28
+128                 24135.60      188559380.55
+256                 42802.30      167196503.24
+512                 80593.51      157409204.36
+1024               143536.04      140171915.93
+2048               230859.57      112724399.58
+4096               355188.29       86715891.77
+8192               481073.88       58724839.43
+16384              552620.10       33729254.06
+32768              644968.82       19682886.40
+65536              702376.46       10717414.18
+131072             537186.97        4098411.34
+262144             537316.53        2049699.90
+524288             538137.55        1026415.92
+1048576            539335.77         514350.68
+2097152            537753.52         256420.86
+4194304            538158.23         128306.92
+real 10.97
+user 0.17
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.32
+256                     1.65
+512                     1.74
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.77
+32768                   9.14
+65536                  12.00
+131072                 17.05
+262144                 25.94
+524288                 44.52
+1048576                82.03
+2097152               157.53
+4194304               308.41
+real 2.41
+user 0.19
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.50
+user 0.17
+sys 0.06
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      14.16
+8                      14.10
+16                     13.55
+32                     13.69
+64                     13.58
+128                    13.99
+256                    15.56
+512                    16.23
+1024                   17.89
+2048                   23.46
+4096                   28.46
+8192                   39.39
+16384                  63.28
+32768                  72.72
+65536                 109.25
+131072                138.69
+262144                223.01
+524288                278.56
+1048576               437.86
+real 2.01
+user 0.17
+sys 0.07
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.26      200264019.95
+2                     409.43      204716680.31
+4                     820.80      205200757.08
+8                    1627.78      203472241.89
+16                   3128.84      195552517.02
+32                   6222.44      194451394.04
+64                  12439.42      194365949.89
+128                 24165.98      188796738.83
+256                 42928.35      167688861.83
+512                 80847.20      157904678.93
+1024               144143.02      140764672.47
+2048               231150.16      112866288.44
+4096               355349.59       86755270.29
+8192               479933.24       58585601.13
+16384              552150.51       33700592.45
+32768              644847.75       19679191.70
+65536              702624.96       10721206.06
+131072             537430.23        4100267.23
+262144             537730.97        2051280.85
+524288             538514.04        1027134.02
+1048576            539973.57         514958.92
+2097152            538009.70         256543.02
+4194304            537677.93         128192.41
+real 11.26
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.84
+32768                   9.18
+65536                  12.07
+131072                 17.00
+262144                 26.04
+524288                 44.56
+1048576                82.04
+2097152               157.48
+4194304               308.34
+real 2.44
+user 0.21
+sys 0.03
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.37
+user 0.20
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.54
+8                      13.35
+16                     13.12
+32                     16.92
+64                     13.54
+128                    15.62
+256                    15.49
+512                    16.39
+1024                   18.18
+2048                   25.35
+4096                   28.71
+8192                   39.85
+16384                  66.04
+32768                  73.61
+65536                 109.08
+131072                136.92
+262144                237.12
+524288                283.07
+1048576               437.89
+real 2.08
+user 0.19
+sys 0.04
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     202.13      202132457.95
+2                     410.04      205017831.45
+4                     820.68      205170949.08
+8                    1619.44      202429449.93
+16                   3145.31      196581610.88
+32                   6238.44      194951164.64
+64                  12462.28      194723080.58
+128                 24013.30      187603941.33
+256                 42792.75      167159179.53
+512                 80441.66      157112625.89
+1024               142966.01      139615246.83
+2048               231744.67      113156579.59
+4096               353451.89       86291965.16
+8192               481305.74       58753142.42
+16384              552327.87       33711418.08
+32768              646124.52       19718155.54
+65536              702937.91       10725981.34
+131072             538860.74        4111181.19
+262144             538593.37        2054570.65
+524288             539171.58        1028388.17
+1048576            540518.35         515478.47
+2097152            538674.92         256860.22
+4194304            537340.22         128111.89
+real 10.91
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.95
+2048                    2.76
+4096                    3.41
+8192                    4.92
+16384                   6.84
+32768                   9.19
+65536                  12.08
+131072                 17.07
+262144                 25.98
+524288                 44.57
+1048576                82.04
+2097152               157.45
+4194304               308.35
+real 2.45
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.28
+user 0.17
+sys 0.06
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.61
+8                      13.29
+16                     13.41
+32                     13.44
+64                     13.74
+128                    14.23
+256                    15.72
+512                    16.69
+1024                   18.20
+2048                   23.63
+4096                   28.51
+8192                   39.54
+16384                  63.43
+32768                  71.63
+65536                 110.17
+131072                136.39
+262144                224.08
+524288                280.95
+1048576               438.01
+real 2.01
+user 0.18
+sys 0.06
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     198.67      198667916.10
+2                     407.82      203910643.73
+4                     819.90      204973817.80
+8                    1621.52      202689595.93
+16                   3124.74      195296203.21
+32                   6192.46      193514249.00
+64                  12442.18      194409123.94
+128                 23961.02      187195481.72
+256                 42825.75      167288074.88
+512                 80745.16      157705386.62
+1024               144123.91      140746001.92
+2048               232692.93      113619594.05
+4096               355235.75       86727477.53
+8192               481047.88       58721665.47
+16384              553418.07       33777958.25
+32768              646544.52       19730972.81
+65536              701817.78       10708889.53
+131072             537006.05        4097031.02
+262144             537489.97        2050361.52
+524288             538708.17        1027504.30
+1048576            539554.18         514558.96
+2097152            538000.32         256538.54
+4194304            537156.01         128067.97
+real 10.95
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.44
+8192                    4.94
+16384                   6.78
+32768                   9.20
+65536                  12.05
+131072                 17.07
+262144                 25.96
+524288                 44.55
+1048576                82.04
+2097152               157.50
+4194304               308.38
+real 2.67
+user 0.16
+sys 0.08
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.28
+user 0.16
+sys 0.07
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.64
+8                      13.36
+16                     13.46
+32                     13.42
+64                     13.65
+128                    14.28
+256                    15.72
+512                    16.52
+1024                   18.08
+2048                   23.95
+4096                   28.60
+8192                   40.00
+16384                  64.04
+32768                  71.58
+65536                 109.55
+131072                137.24
+262144                224.26
+524288                282.76
+1048576               437.91
+real 2.35
+user 0.21
+sys 0.02
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.99      200990328.81
+2                     409.17      204585389.93
+4                     820.58      205146184.19
+8                    1595.41      199426162.90
+16                   3130.01      195625926.55
+32                   6220.19      194380800.34
+64                  12430.65      194228898.00
+128                 23848.23      186314270.69
+256                 42955.33      167794239.04
+512                 80580.79      157384345.94
+1024               143639.56      140273011.83
+2048               232343.74      113449090.55
+4096               355868.16       86881876.07
+8192               481095.68       58727500.10
+16384              552646.31       33730853.97
+32768              647048.65       19746357.65
+65536              702184.82       10714490.12
+131072             537555.13        4101220.16
+262144             537599.10        2050777.82
+524288             538146.47        1026432.94
+1048576            539810.91         514803.80
+2097152            538040.70         256557.80
+4194304            537223.16         128083.98
+real 11.00
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.14
+1                       1.12
+2                       1.12
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.20
+128                     1.29
+256                     1.62
+512                     1.74
+1024                    1.95
+2048                    2.74
+4096                    3.40
+8192                    4.87
+16384                   6.79
+32768                   9.15
+65536                  12.01
+131072                 17.07
+262144                 25.94
+524288                 44.53
+1048576                82.03
+2097152               157.45
+4194304               308.41
+real 2.41
+user 0.21
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.54
+user 0.19
+sys 0.04
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.40
+8                      13.65
+16                     13.27
+32                     13.15
+64                     13.54
+128                    14.24
+256                    15.55
+512                    16.27
+1024                   17.95
+2048                   23.46
+4096                   29.19
+8192                   39.57
+16384                  63.85
+32768                  72.18
+65536                 109.68
+131072                137.08
+262144                224.11
+524288                281.54
+1048576               437.67
+real 2.01
+user 0.18
+sys 0.05
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     201.02      201017849.17
+2                     406.80      203401714.91
+4                     810.42      202604877.46
+8                    1622.76      202844879.63
+16                   3146.26      196641255.97
+32                   6208.89      194027680.21
+64                  12374.45      193350827.43
+128                 24000.73      187505693.61
+256                 42968.98      167847596.35
+512                 78783.17      153873375.29
+1024               143542.08      140177816.38
+2048               231691.04      113130389.13
+4096               353006.57       86183243.76
+8192               479978.90       58591174.08
+16384              552415.35       33716757.18
+32768              645647.67       19703603.16
+65536              701690.45       10706946.53
+131072             537221.02        4098671.10
+262144             537598.73        2050776.39
+524288             538025.05        1026201.34
+1048576            539743.29         514739.32
+2097152            537875.73         256479.13
+4194304            536968.35         128023.23
+real 11.00
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.08
+131072                 17.08
+262144                 25.99
+524288                 44.56
+1048576                82.06
+2097152               157.52
+4194304               308.43
+real 2.55
+user 0.20
+sys 0.03
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.36
+user 0.15
+sys 0.08
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      14.42
+8                      13.17
+16                     13.34
+32                     13.60
+64                     13.53
+128                    13.97
+256                    15.60
+512                    16.25
+1024                   17.92
+2048                   23.60
+4096                   28.40
+8192                   39.35
+16384                  63.82
+32768                  71.26
+65536                 109.06
+131072                135.77
+262144                222.74
+524288                279.94
+1048576               436.85
+real 2.26
+user 0.20
+sys 0.04
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.02      200016602.94
+2                     409.65      204826320.18
+4                     821.10      205275932.25
+8                    1625.73      203216335.10
+16                   3121.60      195100296.13
+32                   6201.39      193793498.27
+64                  12463.46      194741596.54
+128                 24101.32      188291539.29
+256                 42904.34      167595068.06
+512                 80878.06      157964966.95
+1024               144111.53      140733912.23
+2048               231635.50      113103273.84
+4096               354045.39       86436861.95
+8192               479539.20       58537500.01
+16384              553802.24       33801406.34
+32768              647054.01       19746521.39
+65536              703417.33       10733296.68
+131072             537164.92        4098243.13
+262144             537675.92        2051070.85
+524288             538679.71        1027450.00
+1048576            539133.86         514158.12
+2097152            537712.31         256401.21
+4194304            536947.22         128018.19
+real 11.17
+user 0.22
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.76
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.81
+32768                   9.15
+65536                  12.03
+131072                 17.06
+262144                 25.97
+524288                 44.56
+1048576                82.10
+2097152               157.52
+4194304               308.40
+real 2.40
+user 0.15
+sys 0.09
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.38
+user 0.15
+sys 0.08
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.41
+8                      13.24
+16                     13.41
+32                     13.10
+64                     13.55
+128                    13.99
+256                    15.63
+512                    16.27
+1024                   17.94
+2048                   23.43
+4096                   28.37
+8192                   39.35
+16384                  63.46
+32768                  71.27
+65536                 108.93
+131072                136.71
+262144                225.27
+524288                281.29
+1048576               437.18
+real 2.01
+user 0.19
+sys 0.05
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     202.27      202265811.65
+2                     409.42      204711155.36
+4                     821.52      205379478.20
+8                    1618.73      202341550.17
+16                   3137.96      196122275.73
+32                   6231.62      194738170.82
+64                  12453.21      194581457.47
+128                 23953.31      187135272.39
+256                 42798.02      167179783.98
+512                 81070.94      158341680.16
+1024               144068.56      140691952.98
+2048               232222.82      113390046.81
+4096               354550.27       86560124.73
+8192               479610.83       58546243.60
+16384              552651.41       33731165.08
+32768              646224.16       19721196.40
+65536              702319.34       10716542.68
+131072             537101.18        4097756.83
+262144             537505.33        2050420.10
+524288             538578.18        1027256.35
+1048576            539345.69         514360.13
+2097152            537975.42         256526.67
+4194304            537180.98         128073.93
+real 10.94
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.84
+32768                   9.17
+65536                  12.00
+131072                 17.06
+262144                 25.96
+524288                 44.55
+1048576                82.06
+2097152               157.48
+4194304               308.43
+real 2.68
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.27
+user 0.14
+sys 0.09
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.35
+8                      13.16
+16                     13.23
+32                     13.09
+64                     13.47
+128                    13.97
+256                    15.61
+512                    16.24
+1024                   17.95
+2048                   23.69
+4096                   28.49
+8192                   39.33
+16384                  63.07
+32768                  71.29
+65536                 109.13
+131072                136.63
+262144                223.38
+524288                281.64
+1048576               437.39
+real 2.37
+user 0.19
+sys 0.05
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     201.32      201315925.93
+2                     409.00      204499896.40
+4                     809.79      202446658.81
+8                    1624.28      203034614.03
+16                   3158.05      197378375.70
+32                   6230.62      194706789.45
+64                  12211.41      190803246.26
+128                 23980.78      187349859.40
+256                 43235.93      168890362.28
+512                 80896.91      158001771.35
+1024               144091.38      140714234.67
+2048               232904.45      113722874.90
+4096               355639.07       86825943.66
+8192               480151.29       58612218.36
+16384              553918.30       33808490.09
+32768              647283.09       19753512.24
+65536              703753.31       10738423.38
+131072             537718.17        4102464.05
+262144             537724.61        2051256.59
+524288             538080.31        1026306.74
+1048576            539389.26         514401.69
+2097152            538136.57         256603.51
+4194304            536929.99         128014.09
+real 10.96
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.44
+8192                    4.94
+16384                   6.77
+32768                   9.19
+65536                  12.03
+131072                 17.04
+262144                 25.96
+524288                 44.55
+1048576                82.04
+2097152               157.48
+4194304               308.46
+real 2.47
+user 0.18
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 2.00
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.37
+8                      13.17
+16                     13.38
+32                     13.12
+64                     13.44
+128                    13.97
+256                    15.58
+512                    16.47
+1024                   18.01
+2048                   23.46
+4096                   28.49
+8192                   39.49
+16384                  63.40
+32768                  71.24
+65536                 108.82
+131072                136.48
+262144                223.44
+524288                279.82
+1048576               437.89
+real 2.43
+user 0.18
+sys 0.06
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     200.45      200446698.60
+2                     409.32      204659808.03
+4                     820.80      205201168.28
+8                    1618.59      202323359.75
+16                   3149.88      196867518.64
+32                   6205.03      193907167.89
+64                  12262.07      191594806.92
+128                 23894.20      186673448.16
+256                 42941.38      167739747.85
+512                 80628.15      157476863.86
+1024               143821.41      140450594.03
+2048               232145.44      113352265.97
+4096               353550.43       86316023.28
+8192               480112.82       58607521.91
+16384              552107.08       33697941.88
+32768              645675.03       19704438.24
+65536              701115.58       10698174.74
+131072             537425.94        4100234.52
+262144             537440.59        2050173.13
+524288             538610.67        1027318.33
+1048576            539239.73         514259.08
+2097152            534353.67         254799.69
+4194304            536498.04         127911.10
+real 11.29
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.14
+1                       1.12
+2                       1.12
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.74
+1024                    1.95
+2048                    2.75
+4096                    3.40
+8192                    4.89
+16384                   6.81
+32768                   9.17
+65536                  12.04
+131072                 17.06
+262144                 26.00
+524288                 44.54
+1048576                82.02
+2097152               157.47
+4194304               308.34
+real 2.45
+user 0.17
+sys 0.07
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.34
+user 0.22
+sys 0.02
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.36
+8                      13.16
+16                     15.28
+32                     13.32
+64                     15.19
+128                    14.08
+256                    15.58
+512                    16.30
+1024                   22.91
+2048                   23.51
+4096                   29.71
+8192                   39.51
+16384                  65.88
+32768                  71.49
+65536                 149.12
+131072                137.45
+262144                227.35
+524288                294.32
+1048576               437.46
+real 2.08
+user 0.18
+sys 0.06
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 64 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     198.96      198957416.51
+2                     407.83      203914704.31
+4                     819.35      204838509.64
+8                    1623.04      202879441.76
+16                   3126.88      195430196.92
+32                   6207.37      193980265.73
+64                  12436.78      194324731.05
+128                 23960.87      187194283.99
+256                 42528.56      166127172.46
+512                 80454.19      157137097.13
+1024               143719.25      140350829.10
+2048               230590.44      112592986.80
+4096               354684.07       86592789.37
+8192               470520.91       57436634.95
+16384              549432.57       33534702.56
+32768              622068.49       18984023.80
+65536              695057.79       10605740.28
+131072             530770.73        4049459.32
+262144             533362.78        2034617.55
+524288             535480.47        1021347.95
+1048576            533914.46         509180.51
+2097152            538007.05         256541.75
+4194304            536737.56         127968.21
+real 11.05
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.04
+131072                 17.04
+262144                 25.96
+524288                 44.55
+1048576                82.02
+2097152               157.50
+4194304               308.40
+real 2.65
+user 0.19
+sys 0.05
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 128 processes
+real 1.33
+user 0.16
+sys 0.07
+
+time jsrun -n 128 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                      13.41
+8                      13.25
+16                     13.26
+32                     13.23
+64                     13.63
+128                    13.96
+256                    15.70
+512                    16.23
+1024                   17.95
+2048                   23.45
+4096                   28.43
+8192                   39.39
+16384                  63.19
+32768                  71.45
+65536                 108.83
+131072                137.30
+262144                224.00
+524288                280.70
+1048576               438.72
+real 2.65
+user 0.21
+sys 0.03
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_16_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_16_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  16
+==============
+Start run 1 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      27.82       27816638.37
+2                      57.43       28713844.11
+4                     115.91       28977485.29
+8                     230.17       28771221.59
+16                    441.10       27568887.22
+32                    873.74       27304263.89
+64                   1734.97       27108894.63
+128                  3317.69       25919470.43
+256                  5921.16       23129523.98
+512                 10868.32       21227188.55
+1024                18986.72       18541715.78
+2048                30154.12       14723690.68
+4096                44419.45       10844592.54
+8192                55396.47        6762264.66
+16384               62492.72        3814252.75
+32768               74561.41        2275433.79
+65536               83795.65        1278620.15
+131072             103950.80         793081.65
+262144             107219.21         409008.82
+524288             109065.08         208025.13
+1048576            110083.18         104983.50
+2097152            110616.15          52745.89
+4194304            110812.19          26419.69
+real 6.19
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.39
+8192                    4.86
+16384                   6.78
+32768                   9.10
+65536                  11.98
+131072                 17.04
+262144                 26.00
+524288                 44.54
+1048576                82.03
+2097152               157.49
+4194304               308.35
+real 2.45
+user 0.23
+sys 0.01
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.63
+user 0.22
+sys 0.01
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.79
+8                       4.72
+16                      4.70
+32                      4.65
+64                      4.79
+128                     5.15
+256                     5.76
+512                     6.18
+1024                    7.38
+2048                    9.46
+4096                   12.77
+8192                   18.19
+16384                  30.88
+32768                  38.13
+65536                  59.43
+131072                 79.38
+262144                127.47
+524288                165.70
+1048576               257.79
+real 1.25
+user 0.17
+sys 0.06
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.28       28275592.03
+2                      56.64       28321811.00
+4                     115.99       28996752.02
+8                     230.31       28788385.69
+16                    441.94       27621373.55
+32                    875.92       27372550.57
+64                   1717.68       26838812.49
+128                  3313.57       25887231.78
+256                  5905.19       23067167.36
+512                 10854.55       21200283.89
+1024                18834.42       18392984.80
+2048                30131.10       14712453.43
+4096                44847.79       10949166.57
+8192                55881.47        6821468.71
+16384               62713.35        3827719.15
+32768               74436.62        2271625.34
+65536               83747.11        1277879.55
+131072             103867.70         792447.69
+262144             107227.55         409040.65
+524288             109091.10         208074.76
+1048576            110106.12         105005.38
+2097152            110614.98          52745.33
+4194304            110906.16          26442.09
+real 5.59
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.79
+32768                   9.16
+65536                  12.04
+131072                 17.07
+262144                 25.98
+524288                 44.55
+1048576                82.02
+2097152               157.51
+4194304               308.49
+real 2.44
+user 0.19
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.60
+user 0.18
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.81
+8                       4.75
+16                      4.70
+32                      4.66
+64                      4.78
+128                     5.09
+256                     5.76
+512                     6.20
+1024                    7.35
+2048                    9.44
+4096                   12.83
+8192                   18.22
+16384                  30.93
+32768                  38.27
+65536                  59.52
+131072                 79.88
+262144                127.43
+524288                165.93
+1048576               256.62
+real 0.92
+user 0.20
+sys 0.03
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.30       28298674.83
+2                      57.27       28635827.22
+4                     115.47       28868409.11
+8                     229.54       28692282.00
+16                    434.63       27164657.08
+32                    875.44       27357529.79
+64                   1738.57       27165219.18
+128                  3302.77       25802875.11
+256                  5872.64       22939982.82
+512                 10816.77       21126504.85
+1024                18922.78       18479278.12
+2048                29895.01       14597170.83
+4096                44826.80       10944043.45
+8192                55727.20        6802637.03
+16384               62588.42        3820093.87
+32768               74692.55        2279435.66
+65536               83909.31        1280354.40
+131072             103932.70         792943.56
+262144             107213.77         408988.08
+524288             109092.57         208077.56
+1048576            110123.76         105022.20
+2097152            110614.26          52744.99
+4194304            110904.78          26441.76
+real 5.76
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.14
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.75
+4096                    3.40
+8192                    4.90
+16384                   6.84
+32768                   9.17
+65536                  12.05
+131072                 17.00
+262144                 25.97
+524288                 44.52
+1048576                82.00
+2097152               157.48
+4194304               308.36
+real 2.43
+user 0.20
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.58
+user 0.17
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.91
+8                       4.81
+16                      4.75
+32                      4.67
+64                      4.79
+128                     5.10
+256                     5.78
+512                     6.69
+1024                    7.35
+2048                    9.46
+4096                   12.79
+8192                   18.23
+16384                  30.87
+32768                  38.29
+65536                  59.41
+131072                 79.61
+262144                127.69
+524288                165.50
+1048576               257.01
+real 1.24
+user 0.19
+sys 0.04
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.30       28303023.67
+2                      57.22       28610928.26
+4                     114.51       28626589.07
+8                     225.07       28133228.42
+16                    438.10       27381143.38
+32                    876.76       27398638.42
+64                   1723.49       26929594.89
+128                  3263.74       25497957.18
+256                  5856.30       22876179.11
+512                 10964.37       21414789.84
+1024                19006.74       18561269.59
+2048                29876.39       14588079.09
+4096                44944.21       10972706.89
+8192                55751.75        6805633.63
+16384               62579.87        3819572.35
+32768               74619.39        2277202.93
+65536               83910.24        1280368.62
+131072             103931.61         792935.22
+262144             107209.36         408971.24
+524288             109085.15         208063.42
+1048576            110107.62         105006.80
+2097152            110616.17          52745.90
+4194304            110855.70          26430.06
+real 5.57
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.79
+32768                   9.15
+65536                  12.02
+131072                 17.06
+262144                 25.99
+524288                 44.55
+1048576                82.07
+2097152               157.55
+4194304               308.37
+real 2.40
+user 0.17
+sys 0.07
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.56
+user 0.18
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.90
+8                       4.74
+16                      4.71
+32                      4.68
+64                      4.79
+128                     5.07
+256                     5.80
+512                     6.20
+1024                    7.36
+2048                    9.44
+4096                   12.78
+8192                   18.21
+16384                  30.92
+32768                  38.27
+65536                  59.45
+131072                 79.57
+262144                127.63
+524288                165.78
+1048576               257.78
+real 0.89
+user 0.18
+sys 0.05
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.13       28130554.34
+2                      56.18       28091351.76
+4                     115.30       28824430.51
+8                     229.34       28667766.34
+16                    438.25       27390474.21
+32                    855.27       26727290.29
+64                   1714.29       26785737.64
+128                  3310.48       25863157.63
+256                  5906.97       23074101.21
+512                 10936.09       21359552.18
+1024                19040.78       18594516.07
+2048                30049.30       14672509.31
+4096                45057.22       11000298.86
+8192                55485.62        6773147.06
+16384               62567.65        3818826.52
+32768               74508.70        2273825.12
+65536               83848.86        1279432.12
+131072             103863.22         792413.45
+262144             107221.58         409017.88
+524288             109088.73         208070.24
+1048576            110120.85         105019.43
+2097152            110610.99          52743.43
+4194304            110906.81          26442.24
+real 5.90
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.15
+65536                  11.97
+131072                 16.99
+262144                 25.96
+524288                 44.53
+1048576                82.04
+2097152               157.51
+4194304               308.43
+real 2.74
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.63
+user 0.17
+sys 0.07
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.81
+8                       6.49
+16                      4.69
+32                      4.66
+64                      4.81
+128                     5.09
+256                     5.77
+512                     6.19
+1024                    7.34
+2048                    9.43
+4096                   12.81
+8192                   18.25
+16384                  30.86
+32768                  38.12
+65536                  59.71
+131072                 79.63
+262144                127.30
+524288                165.69
+1048576               258.03
+real 0.92
+user 0.16
+sys 0.07
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.23       28228465.32
+2                      56.21       28106309.92
+4                     112.51       28126938.19
+8                     224.13       28016415.87
+16                    423.90       26493630.14
+32                    843.77       26367953.46
+64                   1733.40       27084444.22
+128                  3239.92       25311899.95
+256                  5919.66       23123684.61
+512                 11001.69       21487677.53
+1024                18971.51       18526861.23
+2048                30086.42       14690633.06
+4096                44880.79       10957224.88
+8192                55653.22        6793605.36
+16384               62710.56        3827548.60
+32768               74799.81        2282709.16
+65536               84027.81        1282162.59
+131072             103933.89         792952.67
+262144             107229.86         409049.47
+524288             109093.66         208079.65
+1048576            110107.32         105006.52
+2097152            110579.03          52728.19
+4194304            110786.73          26413.62
+real 5.58
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.83
+32768                   9.17
+65536                  12.05
+131072                 17.06
+262144                 25.99
+524288                 44.56
+1048576                82.04
+2097152               157.49
+4194304               308.38
+real 2.42
+user 0.17
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.78
+user 0.21
+sys 0.02
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.81
+8                       4.74
+16                      4.72
+32                      4.65
+64                      4.81
+128                     5.10
+256                     5.78
+512                     6.19
+1024                    7.37
+2048                    9.43
+4096                   12.76
+8192                   18.20
+16384                  30.89
+32768                  38.28
+65536                  59.52
+131072                 79.69
+262144                127.65
+524288                165.48
+1048576               258.05
+real 0.93
+user 0.19
+sys 0.04
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.18       28175121.59
+2                      56.93       28462834.60
+4                     115.52       28879644.64
+8                     228.46       28557978.27
+16                    442.54       27659050.34
+32                    866.05       27064143.08
+64                   1723.50       26929694.04
+128                  3294.22       25736118.33
+256                  5903.10       23058991.39
+512                 10902.44       21293833.27
+1024                18956.27       18511983.62
+2048                30037.60       14666797.29
+4096                44804.21       10938527.82
+8192                55771.24        6808012.71
+16384               62784.82        3832081.20
+32768               74696.21        2279547.40
+65536               83946.84        1280927.17
+131072             103927.82         792906.31
+262144             107226.21         409035.51
+524288             109086.90         208066.75
+1048576            110112.49         105011.45
+2097152            110617.96          52746.75
+4194304            110905.41          26441.91
+real 5.92
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.43
+8192                    4.91
+16384                   6.83
+32768                   9.16
+65536                  12.00
+131072                 17.08
+262144                 25.98
+524288                 44.57
+1048576                82.05
+2097152               157.49
+4194304               308.36
+real 2.44
+user 0.20
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.64
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.82
+8                       4.81
+16                      4.69
+32                      4.67
+64                      4.79
+128                     5.10
+256                     5.77
+512                     6.20
+1024                    7.34
+2048                    9.43
+4096                   12.77
+8192                   18.21
+16384                  30.89
+32768                  38.18
+65536                  59.51
+131072                 79.74
+262144                127.47
+524288                165.94
+1048576               257.15
+real 0.93
+user 0.19
+sys 0.04
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.31       28309017.25
+2                      57.36       28680581.23
+4                     114.28       28569387.90
+8                     228.09       28511605.11
+16                    442.25       27640594.53
+32                    876.14       27379444.88
+64                   1737.84       27153780.02
+128                  3214.99       25117098.66
+256                  5895.91       23030913.15
+512                 10938.22       21363705.40
+1024                18905.29       18462193.07
+2048                30061.52       14678478.25
+4096                45009.76       10988711.46
+8192                56036.16        6840351.93
+16384               62846.63        3835853.63
+32768               74559.39        2275372.01
+65536               83829.70        1279139.75
+131072             103899.09         792687.16
+262144             107243.39         409101.07
+524288             109089.73         208072.15
+1048576            110111.48         105010.49
+2097152            110618.73          52747.12
+4194304            110905.31          26441.89
+real 5.57
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.89
+16384                   6.77
+32768                   9.16
+65536                  12.07
+131072                 17.06
+262144                 25.98
+524288                 44.57
+1048576                82.02
+2097152               157.51
+4194304               308.37
+real 2.53
+user 0.20
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.86
+user 0.19
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.82
+8                       4.76
+16                      4.72
+32                      4.68
+64                      4.79
+128                     5.07
+256                     5.76
+512                     6.19
+1024                    7.33
+2048                    9.43
+4096                   12.75
+8192                   18.19
+16384                  30.87
+32768                  38.20
+65536                  59.64
+131072                 79.76
+262144                127.69
+524288                166.33
+1048576               257.31
+real 0.93
+user 0.19
+sys 0.04
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.25       28250037.11
+2                      56.88       28438898.86
+4                     113.43       28358549.55
+8                     228.52       28564781.52
+16                    430.51       26906753.38
+32                    873.23       27288343.45
+64                   1691.45       26428834.68
+128                  3247.73       25372887.29
+256                  5866.52       22916100.66
+512                 10919.60       21327352.79
+1024                18908.82       18465648.84
+2048                30022.97       14659654.08
+4096                44823.44       10943222.42
+8192                55936.81        6828223.50
+16384               62754.17        3830210.65
+32768               74913.74        2286185.91
+65536               84042.42        1282385.49
+131072             103966.00         793197.64
+262144             107231.98         409057.53
+524288             109096.43         208084.93
+1048576            110111.03         105010.06
+2097152            110617.81          52746.68
+4194304            110902.98          26441.33
+real 5.58
+user 0.19
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.43
+8192                    4.94
+16384                   6.78
+32768                   9.21
+65536                  12.06
+131072                 17.05
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.52
+4194304               308.42
+real 2.44
+user 0.17
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.55
+user 0.21
+sys 0.02
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.87
+8                       4.73
+16                      4.69
+32                      7.78
+64                      4.79
+128                     5.08
+256                     5.78
+512                     6.18
+1024                    7.33
+2048                   12.25
+4096                   12.74
+8192                   18.19
+16384                  30.83
+32768                  40.90
+65536                  59.68
+131072                 79.65
+262144                137.21
+524288                165.59
+1048576               256.91
+real 1.19
+user 0.21
+sys 0.02
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.31       28312539.47
+2                      57.46       28728586.12
+4                     114.17       28542615.18
+8                     228.74       28592953.07
+16                    441.07       27566645.87
+32                    878.93       27466426.05
+64                   1725.19       26956051.11
+128                  3273.52       25574400.03
+256                  5925.51       23146536.56
+512                 10916.02       21320345.69
+1024                18966.15       18521633.59
+2048                30098.01       14696291.94
+4096                44978.89       10981174.36
+8192                55772.24        6808134.92
+16384               62458.11        3812140.69
+32768               74975.78        2288079.28
+65536               83944.07        1280884.80
+131072             103879.26         792535.82
+262144             107208.32         408967.30
+524288             109089.76         208072.20
+1048576            110100.80         105000.30
+2097152            110618.38          52746.95
+4194304            110836.86          26425.57
+real 5.58
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.77
+32768                   9.17
+65536                  12.12
+131072                 17.10
+262144                 25.99
+524288                 44.57
+1048576                82.06
+2097152               157.51
+4194304               308.39
+real 2.45
+user 0.16
+sys 0.08
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.59
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.97
+8                       4.88
+16                      4.84
+32                      4.82
+64                      4.94
+128                     5.25
+256                     5.91
+512                     6.28
+1024                    7.38
+2048                    9.49
+4096                   12.80
+8192                   18.20
+16384                  30.97
+32768                  38.16
+65536                  59.45
+131072                 79.75
+262144                127.54
+524288                166.00
+1048576               256.57
+real 1.25
+user 0.18
+sys 0.05
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.22       28219410.32
+2                      56.27       28134712.52
+4                     113.70       28425430.99
+8                     226.42       28302163.18
+16                    438.78       27423747.79
+32                    876.26       27383237.50
+64                   1740.49       27195144.82
+128                  3269.11       25539891.86
+256                  5842.99       22824170.08
+512                 10950.46       21387613.31
+1024                19039.12       18592895.48
+2048                29984.30       14640773.47
+4096                45044.09       10997092.64
+8192                55955.21        6830469.87
+16384               62271.82        3800770.44
+32768               74952.56        2287370.69
+65536               83884.77        1279980.00
+131072             103901.05         792702.09
+262144             107198.57         408930.10
+524288             109088.66         208070.11
+1048576            110119.55         105018.18
+2097152            110615.46          52745.56
+4194304            110904.30          26441.64
+real 5.60
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.76
+32768                   9.15
+65536                  12.02
+131072                 17.06
+262144                 25.99
+524288                 44.55
+1048576                82.03
+2097152               157.49
+4194304               308.42
+real 2.44
+user 0.21
+sys 0.02
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.61
+user 0.20
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.90
+8                       4.76
+16                      4.75
+32                      4.72
+64                      4.78
+128                     5.09
+256                     5.78
+512                     6.19
+1024                    7.38
+2048                    9.42
+4096                   12.80
+8192                   18.23
+16384                  30.88
+32768                  38.16
+65536                  59.46
+131072                 79.81
+262144                127.68
+524288                165.72
+1048576               257.16
+real 0.90
+user 0.20
+sys 0.03
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.36       28359790.47
+2                      57.03       28515352.62
+4                     114.62       28655572.33
+8                     230.02       28752366.31
+16                    441.33       27583383.17
+32                    878.75       27460798.64
+64                   1732.91       27076709.59
+128                  3300.22       25782968.84
+256                  5910.86       23089314.16
+512                 10938.05       21363384.49
+1024                18805.94       18365176.47
+2048                30333.14       14811103.47
+4096                45061.01       11001223.03
+8192                55915.38        6825607.33
+16384               62699.79        3826891.75
+32768               74684.16        2279179.65
+65536               83909.81        1280362.09
+131072             103899.11         792687.29
+262144             107210.43         408975.33
+524288             109095.26         208082.69
+1048576            110110.76         105009.80
+2097152            110616.71          52746.16
+4194304            110905.49          26441.93
+real 5.62
+user 0.22
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.92
+16384                   6.82
+32768                   9.16
+65536                  12.00
+131072                 17.12
+262144                 25.97
+524288                 44.57
+1048576                82.07
+2097152               157.50
+4194304               308.42
+real 2.44
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.61
+user 0.20
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.81
+8                       4.78
+16                      4.71
+32                      4.69
+64                      4.79
+128                     5.15
+256                     5.78
+512                     6.18
+1024                    7.37
+2048                    9.46
+4096                   12.82
+8192                   18.23
+16384                  30.87
+32768                  38.21
+65536                  59.48
+131072                 79.71
+262144                127.29
+524288                165.33
+1048576               257.48
+real 0.94
+user 0.19
+sys 0.04
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.14       28138887.39
+2                      56.80       28397604.17
+4                     115.59       28898618.34
+8                     229.50       28687764.50
+16                    440.23       27514500.20
+32                    879.03       27469564.85
+64                   1731.80       27059365.71
+128                  3315.33       25901021.67
+256                  5874.04       22945452.12
+512                 10844.31       21180296.86
+1024                18922.01       18478524.49
+2048                30029.87       14663021.15
+4096                44645.82       10899857.77
+8192                55755.21        6806056.11
+16384               62345.22        3805250.55
+32768               74758.53        2281449.20
+65536               83883.46        1279960.10
+131072             103947.74         793058.30
+262144             107234.95         409068.86
+524288             109098.26         208088.41
+1048576            110119.91         105018.53
+2097152            110616.76          52746.18
+4194304            110904.77          26441.76
+real 5.56
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.43
+8192                    4.92
+16384                   6.76
+32768                   9.17
+65536                  12.03
+131072                 17.06
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.42
+real 2.41
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.60
+user 0.18
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.82
+8                       4.75
+16                      4.69
+32                      4.69
+64                      4.79
+128                     5.08
+256                     5.76
+512                     6.21
+1024                    7.33
+2048                    9.43
+4096                   12.73
+8192                   18.19
+16384                  30.86
+32768                  38.12
+65536                  59.54
+131072                 79.45
+262144                127.47
+524288                165.32
+1048576               256.83
+real 0.94
+user 0.20
+sys 0.04
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      27.96       27959212.31
+2                      56.86       28428303.49
+4                     114.66       28666081.03
+8                     229.61       28701787.86
+16                    441.89       27618170.17
+32                    877.40       27418798.59
+64                   1712.09       26751337.44
+128                  3306.57       25832544.57
+256                  5914.16       23102180.67
+512                 10963.68       21413437.43
+1024                18947.32       18503239.69
+2048                30151.43       14722378.22
+4096                44829.63       10944733.58
+8192                56159.29        6855381.57
+16384               62454.20        3811901.71
+32768               74922.37        2286449.22
+65536               83939.05        1280808.32
+131072             103922.41         792865.08
+262144             107227.12         409038.99
+524288             109084.09         208061.38
+1048576            110121.39         105019.94
+2097152            110615.82          52745.73
+4194304            110804.06          26417.75
+real 5.54
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.20
+65536                  12.09
+131072                 17.01
+262144                 26.00
+524288                 44.55
+1048576                82.04
+2097152               157.51
+4194304               308.36
+real 2.46
+user 0.19
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.61
+user 0.20
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.80
+8                       4.74
+16                      4.70
+32                      4.68
+64                      4.80
+128                     5.09
+256                     5.75
+512                     6.18
+1024                    7.34
+2048                    9.41
+4096                   12.76
+8192                   18.17
+16384                  30.87
+32768                  38.19
+65536                  59.52
+131072                 79.71
+262144                127.76
+524288                165.35
+1048576               257.56
+real 0.95
+user 0.17
+sys 0.06
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.07       28066144.01
+2                      57.28       28641578.06
+4                     116.11       29026720.46
+8                     229.98       28747781.45
+16                    438.53       27408186.59
+32                    870.02       27188126.44
+64                   1742.81       27231435.29
+128                  3344.11       26125888.00
+256                  5913.26       23098657.89
+512                 10857.80       21206650.11
+1024                18886.10       18443458.55
+2048                30194.56       14743439.67
+4096                44912.99       10965086.05
+8192                56079.70        6845666.59
+16384               62565.57        3818699.49
+32768               74475.43        2272809.80
+65536               83923.74        1280574.72
+131072             103890.97         792625.18
+262144             107234.08         409065.55
+524288             109067.12         208029.02
+1048576            110110.44         105009.50
+2097152            110615.97          52745.81
+4194304            110904.87          26441.78
+real 5.57
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.63
+512                     1.76
+1024                    1.98
+2048                    2.77
+4096                    3.42
+8192                    4.89
+16384                   6.77
+32768                   9.14
+65536                  11.98
+131072                 17.07
+262144                 25.97
+524288                 44.56
+1048576                82.05
+2097152               157.51
+4194304               308.39
+real 2.42
+user 0.18
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.58
+user 0.19
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.88
+8                       4.73
+16                      4.67
+32                      4.66
+64                      4.79
+128                     5.09
+256                     5.79
+512                     6.20
+1024                    7.37
+2048                    9.43
+4096                   12.79
+8192                   18.22
+16384                  30.88
+32768                  38.21
+65536                  59.80
+131072                 79.50
+262144                127.76
+524288                166.20
+1048576               256.33
+real 0.94
+user 0.19
+sys 0.04
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.25       28248244.69
+2                      56.03       28014852.25
+4                     114.43       28606676.08
+8                     229.11       28638566.19
+16                    440.85       27553383.33
+32                    875.97       27374014.04
+64                   1737.99       27156156.39
+128                  3290.62       25707934.76
+256                  5886.14       22992738.43
+512                 10875.49       21241190.82
+1024                18831.96       18390586.61
+2048                30007.74       14652215.92
+4096                44827.45       10944202.52
+8192                55564.37        6782760.50
+16384               62860.21        3836682.61
+32768               74512.27        2273933.99
+65536               83865.03        1279678.83
+131072             103932.54         792942.38
+262144             107212.58         408983.52
+524288             109082.73         208058.80
+1048576            110110.65         105009.70
+2097152            110617.85          52746.70
+4194304            110896.94          26439.89
+real 5.59
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.80
+32768                   9.17
+65536                  12.00
+131072                 17.07
+262144                 25.98
+524288                 44.56
+1048576                82.05
+2097152               157.50
+4194304               308.40
+real 2.43
+user 0.21
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.58
+user 0.20
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.82
+8                       4.73
+16                      4.72
+32                      4.67
+64                      4.78
+128                     5.08
+256                     5.76
+512                     6.19
+1024                    7.33
+2048                    9.42
+4096                   12.80
+8192                   18.19
+16384                  30.90
+32768                  38.26
+65536                  60.19
+131072                 79.31
+262144                127.60
+524288                165.53
+1048576               257.34
+real 0.91
+user 0.19
+sys 0.04
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.34       28337643.02
+2                      57.39       28693375.42
+4                     115.56       28889731.51
+8                     227.36       28419987.47
+16                    437.08       27317389.65
+32                    875.49       27359167.08
+64                   1737.03       27141156.28
+128                  3309.12       25852462.22
+256                  5876.00       22953115.57
+512                 10917.24       21322725.28
+1024                19006.64       18561175.39
+2048                29976.25       14636839.15
+4096                44974.69       10980149.95
+8192                55832.64        6815508.32
+16384               62556.24        3818129.66
+32768               74479.38        2272930.17
+65536               83938.44        1280799.03
+131072             103924.45         792880.60
+262144             107221.73         409018.44
+524288             109090.08         208072.81
+1048576            110113.83         105012.73
+2097152            110617.39          52746.48
+4194304            110905.43          26441.92
+real 5.61
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.76
+1024                    1.96
+2048                    2.77
+4096                    3.41
+8192                    4.91
+16384                   6.78
+32768                   9.18
+65536                  12.01
+131072                 17.04
+262144                 25.97
+524288                 44.55
+1048576                82.03
+2097152               157.51
+4194304               308.39
+real 2.46
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.57
+user 0.17
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.78
+8                       4.71
+16                      4.73
+32                      4.72
+64                      4.78
+128                     5.09
+256                     5.76
+512                     6.20
+1024                    7.32
+2048                    9.44
+4096                   12.77
+8192                   18.19
+16384                  30.85
+32768                  38.19
+65536                  59.53
+131072                 79.77
+262144                127.20
+524288                164.87
+1048576               256.88
+real 0.93
+user 0.21
+sys 0.02
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.34       28335525.83
+2                      57.00       28497608.32
+4                     114.13       28532292.20
+8                     230.01       28750816.34
+16                    441.75       27609636.41
+32                    880.66       27520711.75
+64                   1728.32       27005002.78
+128                  3330.64       26020636.60
+256                  5919.30       23122274.83
+512                 10934.41       21356273.53
+1024                18784.66       18344390.13
+2048                30120.44       14707246.79
+4096                44782.09       10933127.48
+8192                56272.95        6869256.05
+16384               62655.04        3824160.33
+32768               74517.18        2274083.97
+65536               83780.02        1278381.66
+131072             103937.33         792978.87
+262144             107199.44         408933.42
+524288             109102.56         208096.61
+1048576            110113.08         105012.02
+2097152            110616.70          52746.15
+4194304            110906.25          26442.11
+real 5.59
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.77
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.14
+65536                  11.97
+131072                 17.01
+262144                 25.98
+524288                 44.54
+1048576                82.02
+2097152               157.50
+4194304               308.38
+real 2.45
+user 0.19
+sys 0.04
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.58
+user 0.17
+sys 0.06
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.87
+8                       4.74
+16                      4.67
+32                      4.66
+64                      4.77
+128                     5.08
+256                     5.77
+512                     6.18
+1024                    7.34
+2048                    9.46
+4096                   12.77
+8192                   18.20
+16384                  30.90
+32768                  38.32
+65536                  59.98
+131072                 79.17
+262144                127.96
+524288                165.55
+1048576               257.37
+real 0.92
+user 0.20
+sys 0.03
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      28.12       28115122.64
+2                      56.66       28328721.62
+4                     115.63       28908669.50
+8                     229.59       28698698.97
+16                    441.38       27586028.54
+32                    868.91       27153520.81
+64                   1719.87       26872916.30
+128                  3310.02       25859552.33
+256                  5903.59       23060881.63
+512                 10936.30       21359953.17
+1024                18984.97       18540010.39
+2048                30075.28       14685193.34
+4096                44754.77       10926456.84
+8192                55854.28        6818149.43
+16384               62890.99        3838561.21
+32768               74628.37        2277477.04
+65536               83879.37        1279897.67
+131072             103910.46         792773.93
+262144             107233.97         409065.12
+524288             109077.48         208048.78
+1048576            110082.00         104982.38
+2097152            110618.81          52747.16
+4194304            110904.52          26441.70
+real 5.59
+user 0.19
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.85
+32768                   9.15
+65536                  12.05
+131072                 17.04
+262144                 25.96
+524288                 44.56
+1048576                82.07
+2097152               157.50
+4194304               308.39
+real 2.42
+user 0.18
+sys 0.05
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.60
+user 0.20
+sys 0.03
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.85
+8                       4.71
+16                      4.69
+32                      4.69
+64                      4.79
+128                     5.10
+256                     5.76
+512                     6.19
+1024                    7.34
+2048                    9.49
+4096                   12.80
+8192                   18.22
+16384                  30.90
+32768                  38.17
+65536                  59.49
+131072                 80.25
+262144                127.46
+524288                164.84
+1048576               257.81
+real 0.93
+user 0.20
+sys 0.04
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 8 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      27.97       27965152.80
+2                      56.81       28403023.37
+4                     115.92       28979978.34
+8                     229.33       28666097.08
+16                    441.55       27597061.34
+32                    869.19       27162135.13
+64                   1723.96       26936848.87
+128                  3311.49       25871037.93
+256                  5909.19       23082777.00
+512                 10929.20       21346096.52
+1024                18985.22       18540252.08
+2048                30161.81       14727447.30
+4096                44767.70       10929614.99
+8192                55734.56        6803535.55
+16384               62922.29        3840471.61
+32768               74616.49        2277114.62
+65536               83810.71        1278849.96
+131072             103887.01         792594.97
+262144             107205.57         408956.80
+524288             109094.51         208081.26
+1048576            110107.21         105006.42
+2097152            110617.60          52746.58
+4194304            110907.03          26442.30
+real 5.82
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.17
+65536                  12.11
+131072                 17.05
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.52
+4194304               308.39
+real 2.42
+user 0.14
+sys 0.10
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 16 processes
+real 0.60
+user 0.15
+sys 0.08
+
+time jsrun -n 16 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.88
+8                       4.72
+16                      4.70
+32                      4.66
+64                      4.79
+128                     5.11
+256                     5.76
+512                     6.23
+1024                    7.36
+2048                    9.44
+4096                   12.77
+8192                   18.20
+16384                  30.86
+32768                  38.28
+65536                  59.44
+131072                 79.33
+262144                127.25
+524288                165.98
+1048576               256.89
+real 1.08
+user 0.18
+sys 0.05
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_32_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_32_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  32
+==============
+Start run 1 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      55.92       55919829.31
+2                     115.19       57595521.95
+4                     228.15       57038615.25
+8                     459.74       57467135.98
+16                    885.73       55357844.68
+32                   1745.30       54540496.32
+64                   3488.07       54501162.67
+128                  6640.51       51878965.97
+256                 11723.54       45795081.32
+512                 21956.53       42883855.53
+1024                38141.74       37247795.32
+2048                60418.13       29501040.60
+4096                87993.94       21482894.56
+8192               121236.57       14799385.94
+16384              138432.12        8449226.22
+32768              160873.28        4909462.84
+65536              174233.76        2658596.17
+131072             194954.51        1487384.91
+262144             196312.05         748871.02
+524288             197244.00         376213.07
+1048576            197732.83         188572.72
+2097152            198028.79          94427.48
+4194304            198305.16          47279.64
+real 6.75
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.22
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.76
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.82
+32768                   9.16
+65536                  12.04
+131072                 17.07
+262144                 25.98
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.38
+real 2.46
+user 0.17
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.90
+user 0.20
+sys 0.03
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.92
+8                       8.75
+16                      8.84
+32                      8.83
+64                      8.88
+128                     9.31
+256                    10.58
+512                    11.25
+1024                   12.29
+2048                   16.38
+4096                   19.79
+8192                   27.89
+16384                  43.60
+32768                  51.32
+65536                  78.62
+131072                101.61
+262144                235.75
+524288                207.75
+1048576               323.78
+real 1.18
+user 0.17
+sys 0.07
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      55.24       55244475.69
+2                     114.67       57336174.76
+4                     229.26       57314705.31
+8                     451.82       56477980.21
+16                    876.44       54777431.91
+32                   1744.50       54515757.40
+64                   3451.95       53936722.32
+128                  6527.26       50994212.85
+256                 11683.94       45640384.97
+512                 21713.72       42409611.41
+1024                37976.31       37086238.54
+2048                58863.00       28741697.47
+4096                89637.49       21884152.90
+8192               118716.66       14491779.38
+16384              138938.58        8480138.13
+32768              161569.53        4930710.75
+65536              177215.13        2704088.36
+131072             195217.62        1489392.26
+262144             196393.76         749182.75
+524288             197235.86         376197.55
+1048576            197745.91         188585.19
+2097152            198038.90          94432.30
+4194304            198343.45          47288.76
+real 5.99
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.75
+32768                   9.19
+65536                  12.03
+131072                 17.07
+262144                 25.97
+524288                 44.54
+1048576                82.05
+2097152               157.49
+4194304               308.41
+real 2.43
+user 0.18
+sys 0.05
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.62
+user 0.18
+sys 0.05
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.97
+8                       8.81
+16                      8.81
+32                      8.81
+64                      8.94
+128                     9.33
+256                    10.64
+512                    11.25
+1024                   12.28
+2048                   16.44
+4096                   19.80
+8192                   27.89
+16384                  43.71
+32768                  51.27
+65536                  78.34
+131072                100.70
+262144                236.86
+524288                208.01
+1048576               324.24
+real 1.15
+user 0.17
+sys 0.07
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.42       56422401.02
+2                     115.39       57695211.52
+4                     231.64       57909315.37
+8                     459.22       57403060.86
+16                    872.69       54543169.00
+32                   1743.36       54479966.38
+64                   3469.95       54217932.79
+128                  6553.45       51198796.83
+256                 11483.11       44855896.05
+512                 21425.96       41847570.23
+1024                37259.17       36385912.40
+2048                59048.91       28832473.47
+4096                88573.48       21624384.03
+8192               118573.25       14474273.60
+16384              134252.95        8194149.49
+32768              157556.57        4808244.94
+65536              177137.47        2702903.31
+131072             196859.51        1501918.90
+262144             196380.90         749133.67
+524288             197236.78         376199.30
+1048576            197742.69         188582.13
+2097152            198029.72          94427.93
+4194304            198330.36          47285.64
+real 5.98
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.41
+8192                    4.89
+16384                   6.77
+32768                   9.14
+65536                  12.01
+131072                 17.04
+262144                 25.96
+524288                 44.56
+1048576                82.05
+2097152               157.51
+4194304               308.39
+real 2.78
+user 0.17
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.66
+user 0.15
+sys 0.08
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.97
+8                       8.77
+16                      8.85
+32                      8.81
+64                      8.90
+128                     9.25
+256                    10.63
+512                    11.22
+1024                   12.26
+2048                   16.43
+4096                   19.79
+8192                   27.87
+16384                  43.84
+32768                  51.36
+65536                  78.50
+131072                101.33
+262144                237.04
+524288                208.19
+1048576               324.37
+real 1.23
+user 0.19
+sys 0.04
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.59       56587091.07
+2                     114.57       57287290.17
+4                     230.23       57557774.18
+8                     455.49       56936399.15
+16                    886.16       55385301.04
+32                   1753.88       54808598.10
+64                   3336.28       52129362.27
+128                  6555.66       51216107.47
+256                 11731.36       45825617.42
+512                 21920.56       42813588.63
+1024                38200.46       37305140.75
+2048                60583.37       29581721.96
+4096                91229.85       22272911.46
+8192               122039.02       14897340.74
+16384              138640.70        8461956.73
+32768              160836.47        4908339.40
+65536              176769.48        2697288.19
+131072             198435.66        1513943.95
+262144             196346.05         749000.73
+524288             197258.62         376240.95
+1048576            197720.43         188560.90
+2097152            198020.66          94423.61
+4194304            198340.35          47288.02
+real 5.69
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.89
+16384                   6.78
+32768                   9.15
+65536                  12.00
+131072                 17.04
+262144                 26.02
+524288                 44.55
+1048576                82.02
+2097152               157.47
+4194304               308.36
+real 2.45
+user 0.22
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.64
+user 0.18
+sys 0.05
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.95
+8                       8.77
+16                      8.84
+32                      8.85
+64                      8.95
+128                     9.31
+256                    10.62
+512                    11.24
+1024                   12.31
+2048                   16.42
+4096                   19.78
+8192                   27.89
+16384                  43.76
+32768                  51.27
+65536                  78.50
+131072                100.86
+262144                235.53
+524288                208.48
+1048576               325.09
+real 1.26
+user 0.22
+sys 0.01
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.17       56173118.53
+2                     114.34       57168729.82
+4                     230.53       57633124.64
+8                     458.89       57361033.93
+16                    877.59       54849669.59
+32                   1736.42       54263040.09
+64                   3480.50       54382837.12
+128                  6571.89       51342861.51
+256                 11679.49       45622998.98
+512                 21906.48       42786093.35
+1024                39189.59       38271088.62
+2048                61857.58       30203896.95
+4096                92949.57       22692767.19
+8192               123058.98       15021847.69
+16384              138897.92        8477656.33
+32768              160791.69        4906973.09
+65536              175901.23        2684039.74
+131072             194990.07        1487656.18
+262144             196406.97         749233.14
+524288             197249.25         376223.08
+1048576            198521.93         189325.26
+2097152            198024.75          94425.56
+4194304            198339.00          47287.70
+real 5.67
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.14
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.75
+4096                    3.41
+8192                    4.88
+16384                   6.76
+32768                   9.17
+65536                  12.01
+131072                 17.07
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.50
+4194304               308.39
+real 2.44
+user 0.19
+sys 0.05
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.67
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.93
+8                       8.71
+16                      8.82
+32                      8.84
+64                      8.92
+128                     9.25
+256                    10.61
+512                    11.21
+1024                   12.31
+2048                   16.41
+4096                   19.78
+8192                   27.90
+16384                  43.73
+32768                  51.37
+65536                  78.33
+131072                101.08
+262144                235.98
+524288                208.88
+1048576               323.14
+real 1.25
+user 0.18
+sys 0.05
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.63       56631530.05
+2                     115.75       57875832.60
+4                     229.83       57456882.09
+8                     459.88       57485460.22
+16                    885.74       55358622.78
+32                   1728.46       54014478.41
+64                   3498.29       54660793.48
+128                  6697.01       52320415.54
+256                 11719.15       45777945.67
+512                 21939.83       42851230.49
+1024                38219.66       37323891.56
+2048                60597.58       29588662.69
+4096                91086.43       22237896.85
+8192               121072.02       14779299.17
+16384              138108.27        8429459.91
+32768              160799.03        4907196.95
+65536              174353.02        2660415.94
+131072             197013.99        1503097.49
+262144             196326.87         748927.56
+524288             197222.88         376172.78
+1048576            197693.30         188535.02
+2097152            198033.43          94429.70
+4194304            198324.67          47284.29
+real 5.67
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.85
+32768                   9.14
+65536                  12.02
+131072                 17.07
+262144                 25.96
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.38
+real 2.42
+user 0.21
+sys 0.03
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.68
+user 0.22
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.95
+8                       8.79
+16                      8.84
+32                      8.81
+64                      8.96
+128                     9.29
+256                    10.62
+512                    11.18
+1024                   12.45
+2048                   16.40
+4096                   19.80
+8192                   27.90
+16384                  43.75
+32768                  51.41
+65536                  78.43
+131072                100.12
+262144                236.27
+524288                207.46
+1048576               324.72
+real 1.29
+user 0.20
+sys 0.03
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      55.96       55955305.70
+2                     115.15       57575444.07
+4                     230.88       57721196.47
+8                     458.93       57366721.81
+16                    879.34       54958856.00
+32                   1752.85       54776640.76
+64                   3484.56       54446219.74
+128                  6623.73       51747906.84
+256                 11762.21       45946129.06
+512                 21973.58       42917141.84
+1024                38324.07       37425847.30
+2048                60714.76       29645876.53
+4096                91079.09       22236105.31
+8192               121994.40       14891894.16
+16384              138538.71        8455731.56
+32768              160665.55        4903123.57
+65536              176781.58        2697472.79
+131072             194973.16        1487527.19
+262144             196338.21         748970.82
+524288             197241.12         376207.58
+1048576            197739.78         188579.35
+2097152            198540.15          94671.32
+4194304            198313.02          47281.51
+real 5.70
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.84
+32768                   9.18
+65536                  12.05
+131072                 17.03
+262144                 25.98
+524288                 44.57
+1048576                82.07
+2097152               157.50
+4194304               308.36
+real 2.41
+user 0.21
+sys 0.03
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.64
+user 0.18
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.94
+8                       8.74
+16                      8.87
+32                      8.83
+64                      8.91
+128                     9.31
+256                    10.62
+512                    11.21
+1024                   12.31
+2048                   16.39
+4096                   19.81
+8192                   27.87
+16384                  43.80
+32768                  51.37
+65536                  78.46
+131072                100.50
+262144                236.82
+524288                207.67
+1048576               323.43
+real 1.29
+user 0.17
+sys 0.06
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.74       56736959.92
+2                     114.18       57091022.83
+4                     230.83       57706818.93
+8                     459.67       57458494.09
+16                    885.73       55358323.51
+32                   1747.60       54612517.79
+64                   3486.59       54477937.50
+128                  6629.71       51794628.23
+256                 11805.51       46115282.80
+512                 21992.59       42954281.38
+1024                37868.78       36981233.47
+2048                60752.59       29664349.62
+4096                90863.25       22183410.88
+8192               121900.23       14880398.79
+16384              138409.57        8447849.54
+32768              160979.28        4912697.67
+65536              176795.99        2697692.66
+131072             197456.85        1506476.24
+262144             196426.94         749309.31
+524288             197224.14         376175.20
+1048576            197745.05         188584.38
+2097152            198265.79          94540.49
+4194304            198337.02          47287.23
+real 5.68
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.05
+131072                 17.04
+262144                 25.97
+524288                 44.57
+1048576                82.06
+2097152               157.54
+4194304               308.40
+real 2.50
+user 0.17
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.68
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       9.00
+8                       8.74
+16                      8.84
+32                      8.82
+64                      8.92
+128                     9.29
+256                    10.61
+512                    11.18
+1024                   12.25
+2048                   16.40
+4096                   19.83
+8192                   27.89
+16384                  43.75
+32768                  51.42
+65536                  78.29
+131072                101.08
+262144                236.48
+524288                208.69
+1048576               324.87
+real 1.19
+user 0.19
+sys 0.04
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.60       56595816.88
+2                     115.68       57838860.03
+4                     228.82       57205936.90
+8                     457.24       57155200.37
+16                    887.22       55451043.34
+32                   1758.34       54948180.22
+64                   3430.83       53606671.52
+128                  6320.99       49382763.68
+256                 11758.43       45931372.97
+512                 21951.28       42873603.26
+1024                38162.05       37267627.79
+2048                60573.53       29576920.07
+4096                91140.28       22251045.25
+8192               121842.35       14873333.38
+16384              138474.08        8451786.97
+32768              160849.27        4908730.22
+65536              176893.87        2699186.31
+131072             198161.45        1511851.90
+262144             196404.89         749225.20
+524288             197214.20         376156.24
+1048576            197728.22         188568.32
+2097152            198022.19          94424.34
+4194304            198334.43          47286.61
+real 5.64
+user 0.17
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.14
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.90
+16384                   6.77
+32768                   9.17
+65536                  12.03
+131072                 17.05
+262144                 25.98
+524288                 44.56
+1048576                82.03
+2097152               157.51
+4194304               308.42
+real 2.44
+user 0.23
+sys 0.01
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.65
+user 0.17
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.92
+8                       8.77
+16                      8.91
+32                      8.86
+64                      8.90
+128                     9.27
+256                    10.66
+512                    11.23
+1024                   12.28
+2048                   16.44
+4096                   19.84
+8192                   27.90
+16384                  43.67
+32768                  51.34
+65536                  78.55
+131072                100.73
+262144                236.41
+524288                207.29
+1048576               324.70
+real 1.31
+user 0.19
+sys 0.04
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.62       56623200.25
+2                     115.92       57960186.33
+4                     229.97       57491495.58
+8                     459.69       57461009.00
+16                    885.18       55324048.19
+32                   1758.72       54959858.91
+64                   3467.02       54172126.64
+128                  6621.00       51726576.55
+256                 11719.57       45779562.47
+512                 21995.20       42959381.15
+1024                38215.00       37319334.70
+2048                60452.06       29517606.21
+4096                91040.73       22226741.85
+8192               121653.79       14850316.35
+16384              138384.87        8446342.34
+32768              160728.81        4905054.15
+65536              176772.62        2697336.15
+131072             197490.75        1506734.81
+262144             196339.51         748975.78
+524288             197226.74         376180.15
+1048576            198328.15         189140.46
+2097152            198023.71          94425.06
+4194304            198332.57          47286.17
+real 5.69
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.75
+4096                    3.41
+8192                    4.90
+16384                   6.76
+32768                   9.13
+65536                  12.05
+131072                 17.08
+262144                 25.97
+524288                 44.57
+1048576                82.05
+2097152               157.52
+4194304               308.43
+real 2.42
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.67
+user 0.17
+sys 0.07
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.97
+8                       8.78
+16                      8.85
+32                      8.85
+64                      8.93
+128                     9.26
+256                    10.63
+512                    11.27
+1024                   12.31
+2048                   16.36
+4096                   19.86
+8192                   27.91
+16384                  43.71
+32768                  51.53
+65536                  78.81
+131072                100.88
+262144                235.90
+524288                207.55
+1048576               324.03
+real 1.25
+user 0.18
+sys 0.05
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      55.79       55789981.23
+2                     116.21       58106345.96
+4                     224.24       56058997.72
+8                     456.94       57117581.34
+16                    885.21       55325751.98
+32                   1743.43       54482343.25
+64                   3451.51       53929819.61
+128                  6680.23       52189300.38
+256                 11796.33       46079424.01
+512                 21991.87       42952876.00
+1024                38169.23       37274641.30
+2048                59039.35       28827806.22
+4096                90735.17       22152141.08
+8192               121201.90       14795154.30
+16384              138276.10        8439703.27
+32768              160335.70        4893057.31
+65536              176989.15        2700640.16
+131072             196820.87        1501624.08
+262144             196327.40         748929.61
+524288             197220.88         376168.98
+1048576            197753.89         188592.81
+2097152            198356.30          94583.66
+4194304            198339.35          47287.79
+real 5.66
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.77
+4096                    3.41
+8192                    4.89
+16384                   6.78
+32768                   9.16
+65536                  12.04
+131072                 17.04
+262144                 26.01
+524288                 44.55
+1048576                82.05
+2097152               157.48
+4194304               308.40
+real 2.43
+user 0.18
+sys 0.05
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.63
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       9.00
+8                       8.74
+16                      8.85
+32                      8.80
+64                      8.93
+128                     9.28
+256                    10.58
+512                    11.27
+1024                   12.32
+2048                   16.36
+4096                   19.79
+8192                   27.88
+16384                  43.77
+32768                  51.35
+65536                  78.57
+131072                101.10
+262144                236.88
+524288                208.09
+1048576               324.80
+real 1.16
+user 0.19
+sys 0.04
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.51       56509490.45
+2                     114.71       57357499.66
+4                     230.13       57533293.74
+8                     459.12       57389452.45
+16                    861.55       53846671.60
+32                   1735.32       54228901.04
+64                   3461.71       54089173.19
+128                  6622.53       51738546.53
+256                 11784.62       46033685.51
+512                 21883.68       42741553.43
+1024                38065.59       37173425.65
+2048                60625.36       29602228.72
+4096                90984.02       22212894.54
+8192               121420.32       14821816.15
+16384              138455.74        8450667.50
+32768              160946.72        4911704.20
+65536              176853.12        2698564.40
+131072             197320.41        1505435.26
+262144             196343.23         748989.99
+524288             198546.01         378696.47
+1048576            197717.06         188557.68
+2097152            197940.53          94385.40
+4194304            198331.57          47285.93
+real 5.63
+user 0.15
+sys 0.08
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.76
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.89
+16384                   6.78
+32768                   9.10
+65536                  11.96
+131072                 17.05
+262144                 25.96
+524288                 44.55
+1048576                82.05
+2097152               157.47
+4194304               308.35
+real 2.67
+user 0.14
+sys 0.09
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.65
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.96
+8                       8.74
+16                      8.85
+32                      8.87
+64                      8.96
+128                     9.25
+256                    10.64
+512                    11.26
+1024                   12.32
+2048                   16.40
+4096                   19.81
+8192                   27.88
+16384                  43.73
+32768                  51.37
+65536                  78.48
+131072                100.44
+262144                236.40
+524288                207.98
+1048576               324.32
+real 1.15
+user 0.20
+sys 0.04
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.70       56695117.58
+2                     115.56       57779756.43
+4                     229.89       57471296.62
+8                     456.31       57038805.88
+16                    882.54       55158564.71
+32                   1760.26       55008041.70
+64                   3493.33       54583232.50
+128                  6579.14       51399532.99
+256                 11642.90       45480063.39
+512                 21940.88       42853274.82
+1024                38219.55       37323782.72
+2048                60146.55       29368432.43
+4096                90949.57       22204484.66
+8192               121564.96       14839472.13
+16384              138043.82        8425525.92
+32768              160887.26        4909889.62
+65536              176696.16        2696169.36
+131072             195021.72        1487897.67
+262144             196384.59         749147.76
+524288             197231.09         376188.46
+1048576            197738.12         188577.77
+2097152            198018.17          94422.42
+4194304            198298.38          47278.02
+real 5.67
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.78
+32768                   9.16
+65536                  12.02
+131072                 17.08
+262144                 25.98
+524288                 44.57
+1048576                82.09
+2097152               157.55
+4194304               308.37
+real 2.41
+user 0.20
+sys 0.03
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.61
+user 0.21
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.94
+8                       8.73
+16                      8.85
+32                      8.81
+64                      8.93
+128                     9.29
+256                    10.63
+512                    11.22
+1024                   12.31
+2048                   16.39
+4096                   19.84
+8192                   27.91
+16384                  43.76
+32768                  51.41
+65536                  78.51
+131072                100.57
+262144                236.08
+524288                207.37
+1048576               323.58
+real 1.46
+user 0.18
+sys 0.05
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.76       56756582.99
+2                     116.12       58061703.03
+4                     229.87       57466523.22
+8                     459.80       57474425.56
+16                    886.59       55412154.96
+32                   1754.46       54826968.44
+64                   3458.13       54033346.60
+128                  6587.12       51461889.56
+256                 11695.86       45686955.13
+512                 21883.43       42741071.75
+1024                38216.61       37320912.47
+2048                60297.59       29442182.77
+4096                91154.76       22254580.23
+8192               121540.44       14836479.25
+16384              138067.59        8426977.16
+32768              160839.44        4908430.21
+65536              176834.84        2698285.58
+131072             197436.81        1506323.28
+262144             196383.51         749143.63
+524288             197214.38         376156.57
+1048576            197743.19         188582.60
+2097152            198031.25          94428.66
+4194304            198335.21          47286.80
+real 5.66
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.77
+32768                   9.19
+65536                  11.98
+131072                 16.99
+262144                 25.97
+524288                 44.57
+1048576                82.05
+2097152               157.52
+4194304               308.40
+real 2.60
+user 0.21
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.61
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.97
+8                       8.74
+16                      8.82
+32                      8.78
+64                      8.94
+128                     9.29
+256                    10.54
+512                    11.20
+1024                   12.28
+2048                   16.37
+4096                   19.81
+8192                   27.90
+16384                  43.74
+32768                  51.39
+65536                  78.44
+131072                100.98
+262144                236.69
+524288                207.61
+1048576               323.81
+real 1.17
+user 0.21
+sys 0.02
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      54.57       54571015.33
+2                     112.36       56180730.78
+4                     221.62       55404120.03
+8                     442.29       55286203.28
+16                    862.36       53897204.77
+32                   1709.36       53417437.98
+64                   3381.77       52840103.99
+128                  6478.27       50611514.61
+256                 11765.28       45958109.90
+512                 22078.50       43122071.68
+1024                38254.36       37357769.60
+2048                60484.77       29533577.14
+4096                91243.40       22276220.79
+8192               121780.03       14865726.49
+16384              138759.60        8469213.62
+32768              161055.73        4915030.69
+65536              176940.61        2699899.41
+131072             196520.66        1499333.68
+262144             196374.76         749110.26
+524288             197234.39         376194.74
+1048576            197745.41         188584.72
+2097152            198026.83          94426.55
+4194304            198340.00          47287.94
+real 5.62
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.16
+65536                  12.01
+131072                 17.09
+262144                 25.97
+524288                 44.56
+1048576                82.04
+2097152               157.50
+4194304               308.40
+real 2.57
+user 0.20
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.61
+user 0.17
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.93
+8                       8.79
+16                      8.90
+32                      8.90
+64                      8.90
+128                     9.29
+256                    10.64
+512                    11.21
+1024                   12.26
+2048                   16.37
+4096                   19.84
+8192                   27.89
+16384                  43.71
+32768                  51.39
+65536                  78.34
+131072                101.07
+262144                236.69
+524288                208.52
+1048576               323.94
+real 1.18
+user 0.18
+sys 0.05
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.51       56510893.80
+2                     116.27       58137323.31
+4                     232.25       58062493.16
+8                     457.97       57246328.60
+16                    887.27       55454196.40
+32                   1752.83       54776084.03
+64                   3479.37       54365196.08
+128                  6600.34       51565184.64
+256                 11717.95       45773259.66
+512                 21975.69       42921279.27
+1024                38272.72       37375700.25
+2048                60466.56       29524687.14
+4096                91057.26       22230775.86
+8192               121583.12       14841689.61
+16384              138405.89        8447625.14
+32768              160882.54        4909745.55
+65536              176857.25        2698627.48
+131072             196965.25        1502725.57
+262144             196355.35         749036.22
+524288             197224.61         376176.09
+1048576            197726.99         188567.15
+2097152            198025.01          94425.69
+4194304            198332.56          47286.17
+real 5.69
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.89
+16384                   6.76
+32768                   9.14
+65536                  12.00
+131072                 17.06
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.51
+4194304               308.39
+real 2.52
+user 0.17
+sys 0.07
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.61
+user 0.18
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.96
+8                       8.73
+16                      8.88
+32                      8.80
+64                      8.91
+128                     9.31
+256                    10.66
+512                    11.22
+1024                   12.31
+2048                   16.39
+4096                   19.81
+8192                   27.90
+16384                  43.79
+32768                  51.29
+65536                  78.37
+131072                100.68
+262144                235.97
+524288                206.75
+1048576               323.26
+real 1.19
+user 0.19
+sys 0.04
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.08       56083375.82
+2                     114.30       57148980.25
+4                     227.95       56986272.10
+8                     451.89       56485644.15
+16                    879.75       54984205.46
+32                   1734.91       54215837.27
+64                   3443.22       53800274.89
+128                  6612.31       51658677.40
+256                 11738.51       45853545.39
+512                 21456.39       41907014.72
+1024                36773.25       35911377.45
+2048                60682.06       29629912.55
+4096                91218.99       22270261.81
+8192               122193.07       14916146.20
+16384              138939.32        8480183.08
+32768              160660.38        4902965.81
+65536              176679.40        2695913.68
+131072             194817.88        1486342.50
+262144             196376.38         749116.45
+524288             197236.02         376197.85
+1048576            197705.68         188546.83
+2097152            198018.53          94422.59
+4194304            198333.36          47286.36
+real 5.69
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.63
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.40
+8192                    4.88
+16384                   6.74
+32768                   9.16
+65536                  12.01
+131072                 17.08
+262144                 25.97
+524288                 44.56
+1048576                82.04
+2097152               157.49
+4194304               308.39
+real 2.63
+user 0.19
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.66
+user 0.21
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.96
+8                       8.80
+16                      8.93
+32                      8.83
+64                      8.94
+128                     9.32
+256                    10.65
+512                    11.22
+1024                   12.30
+2048                   16.33
+4096                   19.82
+8192                   27.84
+16384                  43.69
+32768                  51.43
+65536                  78.32
+131072                100.95
+262144                236.79
+524288                207.97
+1048576               322.85
+real 1.19
+user 0.19
+sys 0.05
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.60       56603982.18
+2                     115.13       57566089.98
+4                     231.70       57923826.77
+8                     460.19       57524276.48
+16                    877.02       54813644.32
+32                   1748.32       54635129.11
+64                   3492.70       54573458.33
+128                  6616.12       51688455.91
+256                 11720.54       45783369.55
+512                 21786.84       42552431.12
+1024                37589.14       36708140.17
+2048                59735.46       29167706.34
+4096                89032.72       21736504.74
+8192               121383.67       14817342.25
+16384              134717.79        8222521.34
+32768              156044.44        4762098.53
+65536              174409.75        2661281.66
+131072             195237.56        1489544.39
+262144             196398.20         749199.70
+524288             197241.24         376207.81
+1048576            197734.56         188574.38
+2097152            197956.24          94392.89
+4194304            198346.66          47289.53
+real 5.93
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.89
+16384                   6.76
+32768                   9.16
+65536                  12.04
+131072                 17.08
+262144                 25.96
+524288                 44.54
+1048576                82.05
+2097152               157.48
+4194304               308.39
+real 2.44
+user 0.14
+sys 0.09
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.70
+user 0.20
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.97
+8                       8.78
+16                      8.85
+32                      8.88
+64                      8.95
+128                     9.31
+256                    10.68
+512                    11.26
+1024                   12.29
+2048                   16.45
+4096                   19.79
+8192                   27.89
+16384                  43.76
+32768                  51.32
+65536                  78.41
+131072                101.12
+262144                236.66
+524288                207.71
+1048576               323.24
+real 1.19
+user 0.18
+sys 0.06
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.01       56008313.73
+2                     113.94       56971592.65
+4                     231.05       57763687.85
+8                     459.22       57402320.76
+16                    882.38       55148494.32
+32                   1754.39       54824620.11
+64                   3472.42       54256628.55
+128                  6587.22       51462665.44
+256                 11572.45       45204883.19
+512                 21804.10       42586125.66
+1024                38912.56       38000547.74
+2048                61541.59       30049602.39
+4096                92100.49       22485470.08
+8192               120528.47       14712948.08
+16384              136709.26        8344071.03
+32768              156628.08        4779909.67
+65536              171741.57        2620568.41
+131072             196822.56        1501636.94
+262144             196318.51         748895.68
+524288             197225.96         376178.67
+1048576            197717.85         188558.44
+2097152            198048.34          94436.81
+4194304            198320.40          47283.27
+real 5.67
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.76
+1024                    1.97
+2048                    2.75
+4096                    3.41
+8192                    4.89
+16384                   6.80
+32768                   9.12
+65536                  11.93
+131072                 17.07
+262144                 25.95
+524288                 44.52
+1048576                82.04
+2097152               157.49
+4194304               308.36
+real 2.41
+user 0.22
+sys 0.02
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.64
+user 0.18
+sys 0.06
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.93
+8                       8.73
+16                      8.84
+32                      8.81
+64                      8.91
+128                     9.31
+256                    10.62
+512                    11.19
+1024                   12.33
+2048                   16.37
+4096                   19.78
+8192                   27.90
+16384                  43.82
+32768                  51.43
+65536                  78.54
+131072                101.04
+262144                235.89
+524288                207.88
+1048576               323.14
+real 1.19
+user 0.21
+sys 0.02
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 16 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      56.17       56168157.81
+2                     115.13       57566089.98
+4                     229.33       57332579.35
+8                     459.20       57400486.67
+16                    885.50       55343962.18
+32                   1739.22       54350537.61
+64                   3471.66       54244643.34
+128                  6641.67       51888009.06
+256                 11769.68       45975318.80
+512                 21830.82       42638329.94
+1024                38256.09       37359459.66
+2048                60713.00       29645018.28
+4096                91126.00       22247559.72
+8192               122063.38       14900314.86
+16384              138268.01        8439209.42
+32768              160893.64        4910084.32
+65536              176827.81        2698178.23
+131072             195039.80        1488035.60
+262144             196353.57         749029.43
+524288             197223.93         376174.80
+1048576            198233.58         189050.28
+2097152            198030.25          94428.18
+4194304            198338.38          47287.55
+real 5.96
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.81
+32768                   9.12
+65536                  11.97
+131072                 17.06
+262144                 25.95
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.38
+real 2.45
+user 0.20
+sys 0.04
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 32 processes
+real 0.66
+user 0.20
+sys 0.03
+
+time jsrun -n 32 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.94
+8                       8.79
+16                      8.90
+32                      8.83
+64                      8.91
+128                     9.29
+256                    10.63
+512                    11.21
+1024                   12.31
+2048                   16.37
+4096                   19.80
+8192                   27.92
+16384                  43.85
+32768                  51.29
+65536                  78.52
+131072                100.70
+262144                235.74
+524288                208.46
+1048576               325.35
+real 1.44
+user 0.19
+sys 0.04
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_4_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_4_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  4
+==============
+Start run 1 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.25        7251072.93
+2                      14.86        7430718.71
+4                      29.99        7497990.77
+8                      59.44        7430140.71
+16                    112.03        7002084.76
+32                    226.68        7083626.64
+64                    449.08        7016928.34
+128                   859.82        6717337.08
+256                  1471.32        5747325.14
+512                  2787.83        5444982.70
+1024                 4785.43        4673267.41
+2048                 7560.12        3691463.98
+4096                11372.78        2776558.82
+8192                15110.36        1844526.05
+16384               17106.82        1044117.56
+32768               19958.68         609090.51
+65536               21745.12         331804.23
+131072              27312.56         208378.30
+262144              27551.87         105102.06
+524288              27674.03          52784.03
+1048576             27730.63          26445.99
+2097152             27765.14          13239.45
+4194304             27781.58           6623.65
+real 5.93
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.90
+16384                   6.77
+32768                   9.16
+65536                  12.02
+131072                 17.05
+262144                 25.99
+524288                 44.56
+1048576                82.03
+2097152               157.48
+4194304               308.44
+real 2.59
+user 0.20
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.63
+8                       2.58
+16                      2.56
+32                      2.58
+64                      2.59
+128                     2.79
+256                     3.07
+512                     3.27
+1024                    3.82
+2048                    4.87
+4096                    6.61
+8192                    9.27
+16384                  15.71
+32768                  24.60
+65536                  40.39
+131072                 63.56
+262144                 83.42
+524288                302.13
+1048576               573.48
+real 0.81
+user 0.15
+sys 0.08
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7301651.77
+2                      14.94        7472231.61
+4                      29.97        7491952.00
+8                      59.36        7420005.96
+16                    113.24        7077633.90
+32                    221.67        6927040.41
+64                    439.79        6871752.69
+128                   838.52        6550923.45
+256                  1484.45        5798614.13
+512                  2788.56        5446400.61
+1024                 4811.95        4699173.94
+2048                 7554.36        3688653.44
+4096                11346.12        2770047.73
+8192                15046.65        1836749.69
+16384               17167.35        1047811.99
+32768               19870.93         606412.57
+65536               21739.17         331713.42
+131072              27313.01         208381.71
+262144              27553.09         105106.69
+524288              27674.30          52784.54
+1048576             27729.84          26445.24
+2097152             27764.88          13239.33
+4194304             27781.33           6623.59
+real 4.84
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.76
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.92
+16384                   6.83
+32768                   9.17
+65536                  12.07
+131072                 17.06
+262144                 25.99
+524288                 44.58
+1048576                82.04
+2097152               157.49
+4194304               308.41
+real 2.46
+user 0.18
+sys 0.06
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.82
+user 0.16
+sys 0.07
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.67
+8                       2.58
+16                      2.56
+32                      2.57
+64                      2.62
+128                     2.73
+256                     3.09
+512                     3.28
+1024                    3.82
+2048                    4.86
+4096                    6.59
+8192                    9.24
+16384                  15.66
+32768                  24.52
+65536                  40.29
+131072                 63.24
+262144                 83.75
+524288                302.27
+1048576               574.78
+real 0.83
+user 0.17
+sys 0.06
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7299374.14
+2                      15.00        7497977.60
+4                      29.78        7444673.86
+8                      59.43        7428127.07
+16                    113.33        7083371.84
+32                    226.41        7075188.81
+64                    449.55        7024263.89
+128                   859.78        6717058.60
+256                  1476.02        5765719.02
+512                  2674.54        5223713.70
+1024                 4795.76        4683362.61
+2048                 7568.85        3695728.37
+4096                11348.37        2770597.55
+8192                15079.62        1840774.18
+16384               17150.93        1046809.39
+32768               19901.10         607333.42
+65536               21761.34         332051.64
+131072              27314.46         208392.82
+262144              27551.77         105101.65
+524288              27672.83          52781.73
+1048576             27729.62          26445.03
+2097152             27764.80          13239.29
+4194304             27780.93           6623.49
+real 4.88
+user 0.19
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.82
+32768                   9.17
+65536                  12.06
+131072                 17.08
+262144                 25.97
+524288                 44.58
+1048576                82.05
+2097152               157.48
+4194304               308.36
+real 2.45
+user 0.19
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.66
+8                       2.57
+16                      2.65
+32                      2.60
+64                      2.61
+128                     2.74
+256                     3.08
+512                     3.27
+1024                    3.82
+2048                    4.86
+4096                    6.57
+8192                    9.22
+16384                  15.73
+32768                  24.51
+65536                  40.60
+131072                 63.28
+262144                 82.08
+524288                302.28
+1048576               573.90
+real 0.84
+user 0.18
+sys 0.05
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.31        7306544.95
+2                      15.02        7507961.08
+4                      29.94        7484364.69
+8                      58.90        7362300.53
+16                    113.18        7074015.76
+32                    225.86        7058104.74
+64                    447.19        6987418.28
+128                   839.07        6555197.58
+256                  1486.47        5806537.07
+512                  2790.91        5451002.30
+1024                 4807.22        4694549.85
+2048                 7589.88        3705996.36
+4096                11286.17        2755413.36
+8192                15067.70        1839318.57
+16384               17119.42        1044886.53
+32768               19900.18         607305.29
+65536               21794.75         332561.57
+131072              27313.09         208382.38
+262144              27552.76         105105.44
+524288              27674.05          52784.06
+1048576             27730.33          26445.71
+2097152             27764.98          13239.37
+4194304             27781.32           6623.58
+real 5.09
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.84
+32768                   9.17
+65536                  12.08
+131072                 17.05
+262144                 26.02
+524288                 44.55
+1048576                82.02
+2097152               157.48
+4194304               308.34
+real 2.47
+user 0.16
+sys 0.07
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.56
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.78
+8                       2.63
+16                      2.55
+32                      2.56
+64                      2.63
+128                     2.73
+256                     3.09
+512                     3.28
+1024                    3.85
+2048                    4.92
+4096                    6.63
+8192                    9.30
+16384                  15.80
+32768                  24.55
+65536                  40.57
+131072                 63.04
+262144                 83.24
+524288                301.91
+1048576               573.19
+real 0.83
+user 0.22
+sys 0.01
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.29        7293975.12
+2                      14.84        7420689.93
+4                      29.67        7417671.09
+8                      59.00        7374542.04
+16                    112.13        7008295.52
+32                    226.52        7078733.77
+64                    441.03        6891052.99
+128                   850.79        6646788.61
+256                  1465.91        5726203.38
+512                  2776.03        5421936.82
+1024                 4781.18        4669118.20
+2048                 7560.16        3691482.08
+4096                11277.69        2753341.87
+8192                15084.01        1841309.34
+16384               17190.13        1049202.52
+32768               19992.59         610125.57
+65536               21726.06         331513.33
+131072              27312.31         208376.40
+262144              27550.38         105096.37
+524288              27672.87          52781.82
+1048576             27729.91          26445.30
+2097152             27765.01          13239.39
+4194304             27781.15           6623.54
+real 4.98
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.14
+1                       1.13
+2                       1.12
+4                       1.12
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.39
+8192                    4.90
+16384                   6.84
+32768                   9.16
+65536                  12.02
+131072                 17.01
+262144                 25.98
+524288                 44.54
+1048576                82.04
+2097152               157.47
+4194304               308.35
+real 2.74
+user 0.19
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.17
+sys 0.06
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.63
+8                       2.58
+16                      2.56
+32                      2.62
+64                      2.63
+128                     2.79
+256                     3.08
+512                     3.27
+1024                    3.81
+2048                    4.88
+4096                    6.57
+8192                    9.23
+16384                  15.76
+32768                  24.55
+65536                  40.11
+131072                 63.02
+262144                 82.52
+524288                302.21
+1048576               573.42
+real 0.84
+user 0.16
+sys 0.07
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.21        7207272.14
+2                      14.98        7491351.29
+4                      29.52        7380665.31
+8                      59.43        7429200.59
+16                    113.15        7071987.31
+32                    225.56        7048826.89
+64                    447.74        6995950.00
+128                   845.54        6605762.91
+256                  1479.08        5777672.46
+512                  2786.27        5441938.55
+1024                 4800.73        4688213.65
+2048                 7523.81        3673734.49
+4096                11348.08        2770527.39
+8192                15039.72        1835903.50
+16384               17058.20        1041149.82
+32768               19956.98         609038.81
+65536               21810.95         332808.62
+131072              27314.10         208390.04
+262144              27552.10         105102.91
+524288              27673.41          52782.84
+1048576             27730.23          26445.61
+2097152             27764.19          13239.00
+4194304             27781.41           6623.60
+real 5.11
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.15
+65536                  12.05
+131072                 17.00
+262144                 25.96
+524288                 44.53
+1048576                82.02
+2097152               157.49
+4194304               308.40
+real 2.48
+user 0.15
+sys 0.08
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.51
+user 0.18
+sys 0.06
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.66
+8                       2.60
+16                      2.58
+32                      2.58
+64                      2.62
+128                     2.72
+256                     3.09
+512                     3.28
+1024                    3.81
+2048                    4.88
+4096                    6.57
+8192                    9.21
+16384                  15.68
+32768                  24.43
+65536                  40.46
+131072                 63.35
+262144                 83.22
+524288                301.70
+1048576               572.98
+real 0.82
+user 0.17
+sys 0.06
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7302109.97
+2                      15.00        7500275.40
+4                      29.98        7494948.23
+8                      59.40        7424417.40
+16                    113.07        7066774.95
+32                    226.59        7080852.27
+64                    447.42        6990940.72
+128                   860.87        6725539.66
+256                  1461.23        5707917.82
+512                  2790.01        5449229.36
+1024                 4803.61        4691022.85
+2048                 7568.54        3695577.92
+4096                11101.89        2710421.91
+8192                15070.51        1839661.70
+16384               17120.18        1044932.59
+32768               19871.96         606444.00
+65536               21779.14         332323.33
+131072              27315.68         208402.10
+262144              27553.10         105106.74
+524288              27673.86          52783.69
+1048576             27725.78          26441.36
+2097152             27764.85          13239.31
+4194304             27781.09           6623.53
+real 4.86
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.83
+32768                   9.16
+65536                  12.08
+131072                 17.04
+262144                 25.98
+524288                 44.55
+1048576                82.06
+2097152               157.49
+4194304               308.35
+real 2.41
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.58
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.73
+8                       2.60
+16                      2.56
+32                      2.61
+64                      2.66
+128                     2.73
+256                     3.18
+512                     3.28
+1024                    3.83
+2048                    4.90
+4096                    6.58
+8192                    9.23
+16384                  15.69
+32768                  24.49
+65536                  40.07
+131072                 63.67
+262144                 82.74
+524288                301.96
+1048576               573.32
+real 0.78
+user 0.17
+sys 0.06
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.28        7282931.65
+2                      14.86        7428208.97
+4                      29.41        7351982.48
+8                      59.19        7398677.14
+16                    111.22        6951561.20
+32                    225.83        7057233.06
+64                    448.22        7003475.47
+128                   842.17        6579434.33
+256                  1466.66        5729155.94
+512                  2789.99        5449203.84
+1024                 4788.82        4676581.51
+2048                 7601.34        3711594.06
+4096                11371.35        2776207.73
+8192                15085.58        1841500.87
+16384               17177.31        1048419.79
+32768               19918.61         607867.78
+65536               21759.95         332030.55
+131072              27312.38         208376.89
+262144              27551.69         105101.35
+524288              27673.17          52782.39
+1048576             27729.89          26445.29
+2097152             27764.76          13239.27
+4194304             27781.31           6623.58
+real 5.01
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.00
+131072                 17.06
+262144                 25.97
+524288                 44.57
+1048576                82.08
+2097152               157.53
+4194304               308.42
+real 2.46
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.53
+user 0.16
+sys 0.07
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.69
+8                       2.68
+16                      2.60
+32                      2.58
+64                      2.61
+128                     2.72
+256                     3.07
+512                     3.28
+1024                    3.83
+2048                    4.87
+4096                    6.60
+8192                    9.23
+16384                  15.69
+32768                  24.47
+65536                  40.34
+131072                 63.49
+262144                 82.89
+524288                302.22
+1048576               573.67
+real 0.86
+user 0.21
+sys 0.02
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.33        7327349.33
+2                      14.74        7370622.54
+4                      29.96        7490351.78
+8                      59.10        7386905.33
+16                    113.26        7078949.09
+32                    225.89        7058945.50
+64                    415.08        6485675.78
+128                   852.35        6659005.34
+256                  1485.70        5803520.02
+512                  2798.10        5465043.15
+1024                 4765.73        4654034.36
+2048                 7583.16        3702716.96
+4096                11337.64        2767977.53
+8192                15006.95        1831902.61
+16384               17179.73        1048567.43
+32768               19981.28         609780.18
+65536               21820.32         332951.64
+131072              27315.83         208403.26
+262144              27552.64         105104.99
+524288              27673.72          52783.44
+1048576             27729.96          26445.35
+2097152             27765.07          13239.42
+4194304             27781.27           6623.57
+real 4.84
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.95
+2048                    2.75
+4096                    3.42
+8192                    4.91
+16384                   6.80
+32768                   9.18
+65536                  12.08
+131072                 17.01
+262144                 25.99
+524288                 44.56
+1048576                82.00
+2097152               157.48
+4194304               308.36
+real 2.44
+user 0.15
+sys 0.09
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.66
+8                       2.63
+16                      2.60
+32                      2.58
+64                      2.62
+128                     2.72
+256                     3.06
+512                     3.26
+1024                    3.83
+2048                    4.87
+4096                    6.61
+8192                    9.26
+16384                  15.73
+32768                  24.48
+65536                  40.83
+131072                 63.35
+262144                 84.63
+524288                302.42
+1048576               573.26
+real 0.84
+user 0.15
+sys 0.08
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7297451.54
+2                      14.97        7484005.86
+4                      29.97        7492232.66
+8                      59.10        7387433.97
+16                    112.57        7035758.14
+32                    225.89        7059077.86
+64                    450.34        7036632.27
+128                   862.87        6741199.05
+256                  1457.78        5694446.67
+512                  2778.02        5425825.57
+1024                 4776.55        4664598.94
+2048                 7564.62        3693661.56
+4096                11380.15        2778356.00
+8192                15098.94        1843132.44
+16384               17183.68        1048808.86
+32768               19946.85         608729.68
+65536               21815.88         332883.90
+131072              27313.14         208382.69
+262144              27550.40         105096.43
+524288              27671.56          52779.32
+1048576             27728.22          26443.69
+2097152             27764.05          13238.93
+4194304             27781.30           6623.58
+real 4.86
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.12
+2                       1.12
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.20
+128                     1.28
+256                     1.62
+512                     1.74
+1024                    1.95
+2048                    2.74
+4096                    3.40
+8192                    4.88
+16384                   6.79
+32768                   9.16
+65536                  12.03
+131072                 17.04
+262144                 25.98
+524288                 44.55
+1048576                82.04
+2097152               157.48
+4194304               308.35
+real 2.72
+user 0.20
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.54
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.70
+8                       2.64
+16                      2.60
+32                      2.58
+64                      2.65
+128                     2.72
+256                     3.08
+512                     3.27
+1024                    3.85
+2048                    5.01
+4096                    6.59
+8192                    9.22
+16384                  15.65
+32768                  24.60
+65536                  39.96
+131072                 63.39
+262144                 82.13
+524288                302.24
+1048576               573.19
+real 0.77
+user 0.19
+sys 0.04
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.35        7347913.97
+2                      14.72        7362071.87
+4                      29.98        7493763.49
+8                      58.53        7316041.56
+16                    113.26        7078796.41
+32                    226.82        7088000.29
+64                    444.19        6940411.69
+128                   861.21        6728233.51
+256                  1477.12        5770004.90
+512                  2785.64        5440703.35
+1024                 4799.63        4687137.25
+2048                 7577.59        3699994.07
+4096                11397.21        2782520.99
+8192                15083.79        1841282.86
+16384               17095.56        1043429.92
+32768               19873.84         606501.38
+65536               21726.92         331526.44
+131072              27315.51         208400.81
+262144              27551.91         105102.21
+524288              27673.93          52783.83
+1048576             27729.54          26444.95
+2097152             27765.11          13239.44
+4194304             27781.36           6623.59
+real 5.14
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.79
+32768                   9.17
+65536                  12.07
+131072                 16.97
+262144                 25.99
+524288                 44.52
+1048576                81.99
+2097152               157.47
+4194304               308.33
+real 2.45
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.77
+user 0.21
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.65
+8                       2.59
+16                      2.60
+32                      2.58
+64                      2.64
+128                     2.73
+256                     3.10
+512                     3.31
+1024                    3.84
+2048                    4.90
+4096                    6.61
+8192                    9.25
+16384                  15.73
+32768                  24.54
+65536                  40.39
+131072                 63.48
+262144                 83.42
+524288                302.31
+1048576               574.08
+real 0.76
+user 0.19
+sys 0.04
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7302159.96
+2                      14.99        7492776.50
+4                      27.88        6969468.28
+8                      59.25        7405924.51
+16                    110.49        6905645.15
+32                    226.96        7092442.23
+64                    448.56        7008690.78
+128                   840.87        6569293.99
+256                  1479.33        5778634.94
+512                  2769.25        5408694.48
+1024                 4808.77        4696068.95
+2048                 7591.94        3707003.11
+4096                11384.16        2779336.33
+8192                15074.72        1840176.10
+16384               17024.46        1039090.33
+32768               19882.95         606779.55
+65536               21746.04         331818.31
+131072              27315.76         208402.70
+262144              27552.22         105103.36
+524288              27673.47          52782.96
+1048576             27730.16          26445.54
+2097152             27765.18          13239.47
+4194304             27781.37           6623.60
+real 4.86
+user 0.21
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.91
+16384                   6.77
+32768                   9.15
+65536                  12.01
+131072                 17.08
+262144                 26.01
+524288                 44.56
+1048576                82.06
+2097152               157.48
+4194304               308.35
+real 2.42
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.56
+user 0.19
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.67
+8                       2.58
+16                      2.65
+32                      2.62
+64                      2.64
+128                     2.73
+256                     3.07
+512                     3.28
+1024                    3.80
+2048                    4.85
+4096                    6.57
+8192                    9.21
+16384                  15.68
+32768                  24.48
+65536                  39.99
+131072                 63.49
+262144                 83.28
+524288                302.09
+1048576               573.62
+real 0.81
+user 0.17
+sys 0.06
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.32        7316568.48
+2                      14.97        7486899.39
+4                      29.89        7471354.94
+8                      59.56        7444509.33
+16                    113.49        7092882.40
+32                    225.25        7039217.24
+64                    448.25        7003877.85
+128                   855.20        6681261.05
+256                  1479.49        5779276.78
+512                  2774.20        5418354.08
+1024                 4787.82        4675609.50
+2048                 7590.48        3706289.31
+4096                11435.32        2791826.58
+8192                15119.80        1845679.29
+16384               17175.39        1048302.76
+32768               19961.99         609191.68
+65536               21808.60         332772.80
+131072              27314.46         208392.76
+262144              27552.27         105103.58
+524288              27673.40          52782.82
+1048576             27730.31          26445.68
+2097152             27764.92          13239.35
+4194304             27780.28           6623.33
+real 4.85
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.77
+4096                    3.42
+8192                    4.92
+16384                   6.85
+32768                   9.19
+65536                  12.12
+131072                 17.13
+262144                 26.02
+524288                 44.62
+1048576                82.10
+2097152               157.49
+4194304               308.37
+real 2.44
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.56
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.67
+8                       2.66
+16                      2.57
+32                      2.58
+64                      2.62
+128                     2.74
+256                     3.09
+512                     3.27
+1024                    3.83
+2048                    4.91
+4096                    6.60
+8192                    9.28
+16384                  15.72
+32768                  24.51
+65536                  39.91
+131072                 63.64
+262144                 83.57
+524288                302.46
+1048576               573.99
+real 0.91
+user 0.20
+sys 0.03
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.23        7234156.07
+2                      14.93        7463448.05
+4                      29.44        7361034.59
+8                      59.15        7393181.52
+16                    112.25        7015451.53
+32                    225.13        7035425.57
+64                    449.60        7025038.77
+128                   853.58        6668618.63
+256                  1482.26        5790076.26
+512                  2766.00        5402352.89
+1024                 4804.33        4691727.82
+2048                 7588.52        3705333.36
+4096                11429.93        2790509.48
+8192                15146.42        1848928.39
+16384               17175.97        1048337.88
+32768               19960.03         609131.79
+65536               21808.13         332765.66
+131072              27315.57         208401.28
+262144              27552.27         105103.57
+524288              27673.88          52783.73
+1048576             27730.54          26445.91
+2097152             27765.16          13239.46
+4194304             27781.36           6623.59
+real 4.87
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.18
+1                       1.14
+2                       1.14
+4                       1.15
+8                       1.16
+16                      1.18
+32                      1.22
+64                      1.23
+128                     1.31
+256                     1.64
+512                     1.76
+1024                    1.97
+2048                    2.78
+4096                    3.45
+8192                    4.95
+16384                   6.85
+32768                   9.23
+65536                  12.11
+131072                 17.01
+262144                 25.97
+524288                 44.53
+1048576                82.04
+2097152               157.51
+4194304               308.36
+real 2.69
+user 0.17
+sys 0.07
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.85
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.62
+8                       2.59
+16                      2.57
+32                      2.56
+64                      2.59
+128                     2.72
+256                     3.08
+512                     3.29
+1024                    3.85
+2048                    4.88
+4096                    6.62
+8192                    9.25
+16384                  15.63
+32768                  24.50
+65536                  40.06
+131072                 63.65
+262144                 84.13
+524288                302.37
+1048576               573.43
+real 0.83
+user 0.13
+sys 0.10
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.29        7285592.97
+2                      14.86        7430865.38
+4                      29.73        7432379.86
+8                      59.23        7404317.99
+16                    111.92        6994913.93
+32                    226.01        7062676.84
+64                    444.64        6947501.31
+128                   851.28        6650597.85
+256                  1471.22        5746953.55
+512                  2785.54        5440509.10
+1024                 4792.44        4680121.04
+2048                 7605.98        3713856.63
+4096                11435.18        2791791.87
+8192                15133.33        1847330.81
+16384               17162.76        1047531.75
+32768               19938.30         608468.55
+65536               21761.58         332055.32
+131072              27311.75         208372.15
+262144              27552.22         105103.37
+524288              27673.74          52783.48
+1048576             27729.98          26445.37
+2097152             27764.92          13239.34
+4194304             27781.34           6623.59
+real 4.89
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.77
+4096                    3.44
+8192                    4.95
+16384                   6.80
+32768                   9.21
+65536                  12.07
+131072                 17.02
+262144                 25.98
+524288                 44.56
+1048576                82.04
+2097152               157.49
+4194304               308.37
+real 2.43
+user 0.21
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.56
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.65
+8                       2.65
+16                      2.57
+32                      2.59
+64                      2.59
+128                     2.74
+256                     3.07
+512                     3.27
+1024                    3.84
+2048                    4.88
+4096                    6.58
+8192                    9.23
+16384                  15.70
+32768                  24.47
+65536                  40.03
+131072                 63.57
+262144                 83.75
+524288                301.61
+1048576               572.99
+real 0.80
+user 0.16
+sys 0.08
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.30        7297189.44
+2                      14.92        7460559.58
+4                      29.70        7426239.46
+8                      59.01        7376250.43
+16                    111.95        6996879.28
+32                    226.08        7064894.92
+64                    448.34        7005280.78
+128                   833.47        6511509.60
+256                  1483.84        5796245.66
+512                  2750.49        5372045.64
+1024                 4798.04        4685584.47
+2048                 7584.25        3703246.16
+4096                11318.64        2763341.00
+8192                15094.79        1842625.66
+16384               17153.42        1046961.63
+32768               19980.07         609743.29
+65536               21800.90         332655.32
+131072              27314.10         208390.03
+262144              27553.59         105108.60
+524288              27673.82          52783.62
+1048576             27730.16          26445.55
+2097152             27765.08          13239.42
+4194304             27781.42           6623.61
+real 4.89
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.14
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.85
+32768                   9.18
+65536                  12.07
+131072                 17.04
+262144                 27.45
+524288                 44.56
+1048576                82.03
+2097152               157.48
+4194304               308.33
+real 2.45
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.60
+user 0.18
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.71
+8                       2.62
+16                      2.57
+32                      2.67
+64                      2.62
+128                     2.74
+256                     3.07
+512                     3.27
+1024                    3.83
+2048                    4.86
+4096                    6.62
+8192                    9.28
+16384                  15.78
+32768                  24.56
+65536                  40.04
+131072                 63.80
+262144                 84.27
+524288                302.50
+1048576               573.78
+real 0.81
+user 0.18
+sys 0.06
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.34        7340282.90
+2                      14.97        7486443.98
+4                      29.98        7495154.50
+8                      56.11        7014094.49
+16                    112.01        7000426.59
+32                    226.09        7065257.59
+64                    449.68        7026214.92
+128                   862.83        6740865.34
+256                  1488.04        5812665.07
+512                  2752.43        5375845.07
+1024                 4815.00        4702146.57
+2048                 7602.72        3712266.84
+4096                11378.42        2777935.12
+8192                15090.58        1842111.47
+16384               17170.56        1048007.93
+32768               19978.85         609706.05
+65536               21807.85         332761.37
+131072              27311.90         208373.25
+262144              27550.12         105095.39
+524288              27672.18          52780.49
+1048576             27645.76          26365.05
+2097152             27764.96          13239.37
+4194304             27781.27           6623.57
+real 4.88
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.14
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.18
+65536                  12.08
+131072                 17.05
+262144                 26.00
+524288                 44.56
+1048576                82.07
+2097152               157.50
+4194304               308.37
+real 2.45
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.19
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.71
+8                       2.58
+16                      2.58
+32                      2.57
+64                      2.63
+128                     2.73
+256                     3.08
+512                     3.27
+1024                    3.83
+2048                    4.87
+4096                    6.59
+8192                    9.24
+16384                  15.73
+32768                  24.51
+65536                  40.06
+131072                 63.83
+262144                 84.99
+524288                301.78
+1048576               573.69
+real 0.82
+user 0.22
+sys 0.02
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.31        7306202.97
+2                      15.02        7510696.88
+4                      29.83        7456322.26
+8                      59.39        7423302.21
+16                    113.05        7065616.39
+32                    226.59        7081067.71
+64                    448.23        7003532.95
+128                   856.04        6687785.44
+256                  1466.71        5729350.84
+512                  2791.51        5452165.55
+1024                 4801.18        4688648.12
+2048                 7311.85        3570237.16
+4096                11336.63        2767730.94
+8192                15094.17        1842550.33
+16384               17183.72        1048811.18
+32768               19996.30         610238.63
+65536               21818.21         332919.47
+131072              27310.84         208365.18
+262144              27552.11         105102.97
+524288              27674.38          52784.69
+1048576             27729.65          26445.06
+2097152             27764.97          13239.37
+4194304             27781.37           6623.59
+real 4.86
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.74
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.17
+65536                  12.06
+131072                 16.98
+262144                 26.01
+524288                 44.53
+1048576                81.99
+2097152               157.49
+4194304               308.36
+real 2.45
+user 0.19
+sys 0.05
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.58
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.65
+8                       2.59
+16                      2.57
+32                      2.68
+64                      2.63
+128                     2.74
+256                     3.14
+512                     3.27
+1024                    3.82
+2048                    4.88
+4096                    6.59
+8192                    9.24
+16384                  15.75
+32768                  24.56
+65536                  40.37
+131072                 64.00
+262144                 84.14
+524288                302.71
+1048576               574.20
+real 0.89
+user 0.20
+sys 0.03
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.32        7323777.33
+2                      14.84        7422135.71
+4                      29.93        7481547.46
+8                      59.06        7383053.58
+16                    113.19        7074242.52
+32                    227.15        7098471.89
+64                    442.67        6916791.54
+128                   859.77        6716924.66
+256                  1479.94        5781017.76
+512                  2778.11        5426000.38
+1024                 4822.80        4709767.91
+2048                 7573.91        3698200.28
+4096                11409.29        2785472.28
+8192                15086.61        1841627.25
+16384               17189.90        1049188.41
+32768               19947.71         608755.79
+65536               21812.61         332833.96
+131072              27305.41         208323.78
+262144              27551.89         105102.12
+524288              27673.28          52782.59
+1048576             27729.41          26444.83
+2097152             27765.04          13239.40
+4194304             27781.08           6623.53
+real 4.86
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.95
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.16
+65536                  12.07
+131072                 17.02
+262144                 26.00
+524288                 44.57
+1048576                82.07
+2097152               157.49
+4194304               308.38
+real 2.44
+user 0.17
+sys 0.06
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.19
+sys 0.04
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.67
+8                       2.60
+16                      2.56
+32                      2.62
+64                      2.61
+128                     2.74
+256                     3.09
+512                     3.30
+1024                    3.81
+2048                    4.89
+4096                    6.58
+8192                    9.24
+16384                  15.67
+32768                  24.47
+65536                  39.78
+131072                 63.10
+262144                 83.32
+524288                302.26
+1048576               573.51
+real 0.81
+user 0.19
+sys 0.04
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 2 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                       7.27        7269757.41
+2                      15.00        7499383.35
+4                      29.64        7410525.15
+8                      59.53        7441730.67
+16                    113.53        7095638.68
+32                    224.64        7020057.07
+64                    447.16        6986930.07
+128                   843.82        6592314.29
+256                  1481.21        5785980.21
+512                  2767.99        5406231.86
+1024                 4809.03        4696315.34
+2048                 7558.12        3690490.13
+4096                11376.39        2777439.04
+8192                15096.07        1842781.91
+16384               17058.51        1041169.04
+32768               19906.41         607495.38
+65536               21796.91         332594.47
+131072              27316.15         208405.72
+262144              27553.19         105107.08
+524288              27673.63          52783.26
+1048576             27730.26          26445.64
+2097152             27764.73          13239.25
+4194304             27780.58           6623.41
+real 4.85
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.14
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.42
+8192                    4.92
+16384                   6.85
+32768                   9.16
+65536                  12.02
+131072                 17.05
+262144                 25.98
+524288                 44.57
+1048576                82.04
+2097152               157.50
+4194304               308.36
+real 2.71
+user 0.20
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 4 processes
+real 0.55
+user 0.21
+sys 0.03
+
+time jsrun -n 4 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       2.64
+8                       2.60
+16                      2.64
+32                      2.65
+64                      2.62
+128                     2.73
+256                     3.10
+512                     3.26
+1024                    3.83
+2048                    4.87
+4096                    6.61
+8192                    9.27
+16384                  15.74
+32768                  24.53
+65536                  40.22
+131072                 63.14
+262144                 82.88
+524288                301.84
+1048576               573.00
+real 0.80
+user 0.20
+sys 0.03
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_64_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_64_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  64
+==============
+Start run 1 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.69      100692407.80
+2                     204.74      102370721.97
+4                     406.52      101629142.95
+8                     813.90      101738041.43
+16                   1574.81       98425859.09
+32                   3115.41       97356680.56
+64                   6213.27       97082408.17
+128                 12007.90       93811681.29
+256                 21542.72       84151253.66
+512                 40191.63       78499283.81
+1024                72202.88       70510620.15
+2048               114383.89       55851509.16
+4096               177905.14       43433871.72
+8192               237323.45       28970148.02
+16384              271469.16       16569162.38
+32768              315964.55        9642472.83
+65536              346393.83        5285550.44
+131072             434468.50        3314731.61
+262144             439726.25        1677422.51
+524288             442204.49         843438.12
+1048576            443349.16         422810.71
+2097152            444083.41         211755.47
+4194304            443916.96         105838.05
+real 9.51
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.81
+32768                   9.13
+65536                  11.95
+131072                 17.05
+262144                 25.96
+524288                 44.54
+1048576                82.02
+2097152               157.47
+4194304               308.37
+real 2.41
+user 0.17
+sys 0.07
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.90
+user 0.20
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.77
+8                       7.54
+16                      7.45
+32                      7.49
+64                      7.68
+128                     7.90
+256                     8.95
+512                     9.70
+1024                   11.14
+2048                   14.54
+4096                   19.48
+8192                   27.59
+16384                  46.95
+32768                  57.97
+65536                  90.70
+131072                116.89
+262144                477.65
+524288                232.00
+1048576               358.20
+real 1.63
+user 0.17
+sys 0.07
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.98      100975488.30
+2                     201.57      100783532.92
+4                     398.50       99624801.71
+8                     813.86      101732734.99
+16                   1581.12       98820093.87
+32                   3123.76       97617568.87
+64                   6189.16       96705588.15
+128                 12001.79       93763963.87
+256                 21341.30       83364438.96
+512                 40035.71       78194740.03
+1024                71593.58       69915602.85
+2048               114436.63       55877262.10
+4096               177880.16       43427774.61
+8192               236823.20       28909081.64
+16384              271553.74       16574324.96
+32768              316973.07        9673250.54
+65536              347081.67        5296046.00
+131072             434439.95        3314513.81
+262144             439670.39        1677209.42
+524288             442204.00         843437.20
+1048576            443374.04         422834.43
+2097152            444085.55         211756.49
+4194304            444422.42         105958.56
+real 8.40
+user 0.23
+sys 0.01
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.79
+32768                   9.15
+65536                  12.05
+131072                 17.06
+262144                 25.97
+524288                 44.56
+1048576                82.05
+2097152               157.53
+4194304               308.41
+real 2.53
+user 0.16
+sys 0.08
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.88
+user 0.22
+sys 0.02
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.92
+8                       7.49
+16                      7.43
+32                      7.47
+64                      7.67
+128                     7.90
+256                     9.04
+512                     9.77
+1024                   11.44
+2048                   14.44
+4096                   19.38
+8192                   27.54
+16384                  47.05
+32768                  58.03
+65536                  90.77
+131072                117.27
+262144                481.14
+524288                232.66
+1048576               358.66
+real 1.39
+user 0.18
+sys 0.05
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.88      100878102.51
+2                     205.96      102981484.95
+4                     410.05      102513328.48
+8                     810.47      101309053.46
+16                   1583.98       98998893.03
+32                   3143.58       98236868.85
+64                   6238.78       97480871.52
+128                 11930.37       93206018.52
+256                 21488.56       83939689.66
+512                 40055.44       78233272.67
+1024                71427.23       69753152.86
+2048               114255.64       55788887.01
+4096               177551.63       43347566.63
+8192               236558.03       28876712.79
+16384              271642.29       16579729.68
+32768              317395.37        9686137.92
+65536              347211.29        5298023.80
+131072             434476.20        3314790.31
+262144             439720.71        1677401.38
+524288             442208.02         843444.86
+1048576            443384.01         422843.94
+2097152            444083.26         211755.40
+4194304            444424.53         105959.06
+real 8.05
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.16
+65536                  12.02
+131072                 17.05
+262144                 25.96
+524288                 44.55
+1048576                82.04
+2097152               157.56
+4194304               308.39
+real 2.38
+user 0.16
+sys 0.07
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.89
+user 0.17
+sys 0.07
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.83
+8                       7.42
+16                      7.44
+32                      7.49
+64                      7.65
+128                     7.88
+256                     8.93
+512                     9.52
+1024                   11.04
+2048                   14.45
+4096                   19.45
+8192                   27.54
+16384                  46.93
+32768                  58.04
+65536                  90.85
+131072                117.48
+262144                480.64
+524288                232.03
+1048576               359.93
+real 1.66
+user 0.22
+sys 0.01
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     101.15      101149588.78
+2                     205.17      102585269.00
+4                     410.03      102508043.48
+8                     806.65      100831118.22
+16                   1567.29       97955607.17
+32                   3112.00       97250027.54
+64                   6216.11       97126792.20
+128                 12010.84       93834676.86
+256                 21521.19       84067142.06
+512                 40140.84       78400086.98
+1024                72261.86       70568225.83
+2048               114889.87       56098569.13
+4096               178174.18       43499556.30
+8192               237263.75       28962859.52
+16384              269669.57       16459324.45
+32768              316090.41        9646313.76
+65536              345531.23        5272388.10
+131072             434471.80        3314756.78
+262144             439725.38        1677419.19
+524288             442204.46         843438.08
+1048576            443379.41         422839.55
+2097152            444060.10         211744.36
+4194304            444011.50         105860.59
+real 8.40
+user 0.22
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.90
+16384                   6.81
+32768                   9.14
+65536                  12.00
+131072                 17.06
+262144                 25.96
+524288                 44.56
+1048576                82.05
+2097152               157.50
+4194304               308.40
+real 2.68
+user 0.18
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.86
+user 0.21
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.49
+8                       7.40
+16                      7.42
+32                      7.47
+64                      7.60
+128                     7.96
+256                     9.00
+512                     9.50
+1024                   11.09
+2048                   14.83
+4096                   19.41
+8192                   27.51
+16384                  47.03
+32768                  58.05
+65536                  91.25
+131072                116.87
+262144                479.09
+524288                232.42
+1048576               358.67
+real 1.61
+user 0.18
+sys 0.05
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.92      100920107.54
+2                     205.50      102749450.88
+4                     406.12      101529133.85
+8                     812.42      101551990.11
+16                   1573.82       98363458.74
+32                   3131.99       97874760.45
+64                   6186.55       96664918.71
+128                 11969.59       93512437.66
+256                 21558.81       84214092.95
+512                 40194.67       78505211.70
+1024                72084.15       70394674.20
+2048               114955.90       56130811.10
+4096               178077.43       43475934.97
+8192               237107.02       28943727.77
+16384              272178.39       16612450.43
+32768              317158.96        9678923.45
+65536              347382.72        5300639.71
+131072             434521.02        3315132.32
+262144             439680.89        1677249.50
+524288             442209.00         843446.73
+1048576            443373.94         422834.34
+2097152            443774.60         211608.22
+4194304            444178.03         105900.29
+real 8.12
+user 0.22
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.63
+512                     1.77
+1024                    1.97
+2048                    2.75
+4096                    3.41
+8192                    4.88
+16384                   6.76
+32768                   9.16
+65536                  12.01
+131072                 17.03
+262144                 25.97
+524288                 44.56
+1048576                82.02
+2097152               157.48
+4194304               308.36
+real 2.42
+user 0.21
+sys 0.02
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.17
+user 0.20
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.76
+8                       7.47
+16                      7.49
+32                      7.50
+64                      7.63
+128                     7.97
+256                     8.91
+512                     9.55
+1024                   11.07
+2048                   14.44
+4096                   19.44
+8192                   27.57
+16384                  47.18
+32768                  58.34
+65536                  90.67
+131072                117.54
+262144                479.34
+524288                235.46
+1048576               358.93
+real 1.48
+user 0.16
+sys 0.07
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     101.44      101439419.42
+2                     204.43      102215858.13
+4                     405.42      101356133.18
+8                     815.67      101958621.13
+16                   1568.14       98008719.33
+32                   3117.80       97431388.89
+64                   6217.90       97154760.23
+128                 12028.77       93974741.54
+256                 21475.40       83888287.67
+512                 40111.59       78342954.70
+1024                72245.38       70552132.45
+2048               114810.59       56059857.04
+4096               177780.08       43403338.88
+8192               236311.03       28846561.51
+16384              271425.11       16566473.74
+32768              317307.39        9683453.21
+65536              347022.09        5295136.92
+131072             434470.28        3314745.19
+262144             439715.49        1677381.46
+524288             442206.53         843442.02
+1048576            443383.46         422843.42
+2097152            444083.56         211755.54
+4194304            444413.62         105956.46
+real 8.06
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.17
+65536                  12.02
+131072                 17.14
+262144                 25.95
+524288                 44.57
+1048576                82.07
+2097152               157.53
+4194304               308.42
+real 2.46
+user 0.18
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.86
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.86
+8                       7.41
+16                      7.44
+32                      7.46
+64                      7.66
+128                     7.90
+256                     8.90
+512                     9.49
+1024                   11.00
+2048                   14.44
+4096                   19.48
+8192                   27.93
+16384                  47.05
+32768                  58.79
+65536                  91.69
+131072                116.62
+262144                477.59
+524288                233.12
+1048576               357.31
+real 1.71
+user 0.22
+sys 0.01
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     101.42      101417969.80
+2                     205.83      102913848.85
+4                     407.24      101810820.78
+8                     813.62      101702726.11
+16                   1587.27       99204571.16
+32                   3134.59       97955841.43
+64                   6179.27       96551171.41
+128                 12023.70       93935129.72
+256                 21454.34       83806003.83
+512                 39898.79       77927316.04
+1024                71713.07       70032297.61
+2048               114596.94       55955535.02
+4096               177024.60       43218896.11
+8192               237453.78       28986056.97
+16384              268646.33       16396870.89
+32768              315698.50        9634353.70
+65536              345488.61        5271737.88
+131072             434534.43        3315234.60
+262144             439707.04        1677349.24
+524288             442224.38         843476.06
+1048576            443366.69         422827.43
+2097152            444089.09         211758.18
+4194304            444176.38         105899.90
+real 8.11
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.76
+32768                   9.15
+65536                  12.07
+131072                 17.07
+262144                 25.98
+524288                 44.57
+1048576                82.08
+2097152               157.51
+4194304               308.41
+real 2.46
+user 0.17
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.12
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.84
+8                       7.47
+16                      7.43
+32                      7.50
+64                      7.68
+128                     7.91
+256                     8.93
+512                     9.53
+1024                   11.07
+2048                   14.45
+4096                   19.71
+8192                   27.56
+16384                  46.96
+32768                  58.18
+65536                  90.69
+131072                116.75
+262144                477.00
+524288                233.55
+1048576               358.65
+real 1.40
+user 0.18
+sys 0.05
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.91      100908521.60
+2                     205.46      102732132.99
+4                     405.50      101373793.09
+8                     809.82      101227382.01
+16                   1578.53       98658000.69
+32                   3126.09       97690208.51
+64                   6114.54       95539633.32
+128                 12020.29       93908553.79
+256                 21538.34       84134141.37
+512                 39936.97       78001902.06
+1024                71978.55       70291555.51
+2048               115307.17       56302328.11
+4096               177887.71       43429616.45
+8192               237716.92       29018178.16
+16384              271192.92       16552302.49
+32768              317031.32        9675028.18
+65536              347286.58        5299172.71
+131072             434522.74        3315145.41
+262144             439744.24        1677491.14
+524288             442205.56         843440.17
+1048576            443386.04         422845.88
+2097152            444086.27         211756.83
+4194304            443671.52         105779.53
+real 8.34
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.98
+2048                    2.76
+4096                    3.40
+8192                    4.88
+16384                   6.76
+32768                   9.16
+65536                  12.07
+131072                 17.05
+262144                 25.97
+524288                 44.55
+1048576                82.04
+2097152               157.47
+4194304               308.37
+real 2.46
+user 0.18
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.89
+user 0.22
+sys 0.01
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.75
+8                       7.46
+16                      7.48
+32                      7.51
+64                      7.74
+128                     7.89
+256                     8.89
+512                     9.53
+1024                   11.02
+2048                   14.45
+4096                   19.44
+8192                   27.54
+16384                  46.95
+32768                  58.03
+65536                  90.65
+131072                117.38
+262144                483.41
+524288                233.37
+1048576               358.53
+real 1.68
+user 0.20
+sys 0.03
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.62      100617362.19
+2                     204.61      102306542.97
+4                     406.11      101527976.21
+8                     816.18      102022618.33
+16                   1585.89       99117812.75
+32                   3123.91       97622315.09
+64                   6226.22       97284674.53
+128                 12022.19       93923325.91
+256                 21435.72       83733294.74
+512                 39926.56       77981557.06
+1024                71743.17       70061693.97
+2048               114725.17       56018149.00
+4096               177151.74       43249937.12
+8192               236772.90       28902941.44
+16384              271537.90       16573357.91
+32768              317288.30        9682870.39
+65536              346690.93        5290083.73
+131072             434471.87        3314757.31
+262144             439691.31        1677289.24
+524288             442213.59         843455.48
+1048576            443373.34         422833.76
+2097152            444083.99         211755.75
+4194304            444419.32         105957.82
+real 8.36
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.77
+32768                   9.16
+65536                  12.05
+131072                 17.02
+262144                 25.99
+524288                 44.58
+1048576                82.07
+2097152               157.52
+4194304               308.33
+real 2.65
+user 0.17
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.93
+user 0.22
+sys 0.02
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.68
+8                       7.40
+16                      7.47
+32                      7.43
+64                      7.66
+128                     7.88
+256                     8.99
+512                     9.50
+1024                   11.03
+2048                   14.49
+4096                   19.77
+8192                   28.03
+16384                  46.99
+32768                  57.96
+65536                  90.66
+131072                117.11
+262144                476.66
+524288                233.62
+1048576               358.69
+real 1.70
+user 0.23
+sys 0.00
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     101.59      101591685.75
+2                     203.56      101778135.59
+4                     406.29      101573597.21
+8                     814.67      101834209.13
+16                   1585.26       99078492.61
+32                   3133.55       97923289.92
+64                   6190.16       96721207.73
+128                 12029.58       93981080.80
+256                 21497.61       83975037.11
+512                 40034.85       78193068.15
+1024                71432.95       69758736.28
+2048               114426.83       55872475.44
+4096               177345.52       43297245.95
+8192               236705.22       28894679.74
+16384              271563.39       16574913.84
+32768              316915.46        9671492.28
+65536              347000.63        5294809.46
+131072             434447.58        3314572.01
+262144             439726.38        1677423.03
+524288             442194.06         843418.24
+1048576            443386.02         422845.86
+2097152            444045.76         211737.52
+4194304            443800.05         105810.18
+real 8.09
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.14
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.80
+32768                   9.14
+65536                  12.00
+131072                 17.07
+262144                 25.96
+524288                 44.55
+1048576                82.01
+2097152               157.47
+4194304               308.39
+real 2.45
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.11
+user 0.19
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.69
+8                       7.45
+16                      7.48
+32                      7.45
+64                      7.65
+128                     7.92
+256                     8.91
+512                     9.56
+1024                   11.06
+2048                   14.43
+4096                   19.47
+8192                   27.60
+16384                  47.02
+32768                  57.98
+65536                  91.01
+131072                117.61
+262144                478.37
+524288                232.48
+1048576               357.41
+real 1.66
+user 0.18
+sys 0.05
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.06      100059116.96
+2                     205.00      102502194.69
+4                     408.41      102103186.04
+8                     808.20      101024451.07
+16                   1570.03       98126822.21
+32                   3130.46       97826886.54
+64                   6229.34       97333406.84
+128                 11964.04       93469033.82
+256                 21550.83       84182938.40
+512                 40179.14       78474889.57
+1024                71498.16       69822426.70
+2048               114443.35       55880540.07
+4096               177680.81       43379105.21
+8192               236491.37       28868575.95
+16384              270706.99       16522643.48
+32768              316478.38        9658153.71
+65536              346384.29        5285404.76
+131072             434419.67        3314359.06
+262144             439715.18        1677380.31
+524288             442194.68         843419.42
+1048576            443375.38         422835.72
+2097152            444080.83         211754.24
+4194304            444419.65         105957.90
+real 8.10
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.31
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.77
+32768                   9.15
+65536                  11.99
+131072                 17.05
+262144                 26.00
+524288                 44.54
+1048576                82.08
+2097152               157.57
+4194304               308.45
+real 2.44
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.83
+user 0.20
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       8.26
+8                       7.90
+16                      7.82
+32                      7.52
+64                      7.67
+128                     7.88
+256                     8.92
+512                     9.53
+1024                   11.05
+2048                   14.43
+4096                   19.43
+8192                   27.57
+16384                  46.89
+32768                  58.07
+65536                  90.95
+131072                117.23
+262144                476.83
+524288                232.85
+1048576               357.27
+real 1.64
+user 0.22
+sys 0.02
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.50      100498024.63
+2                     203.82      101907988.23
+4                     409.11      102276603.28
+8                     817.93      102241780.84
+16                   1583.41       98963397.07
+32                   3141.49       98171507.73
+64                   6211.36       97052458.09
+128                 11901.77       92982584.38
+256                 21414.84       83651724.54
+512                 39618.78       77380430.61
+1024                71307.40       69636130.82
+2048               114803.08       56056189.76
+4096               176886.93       43185285.96
+8192               236912.99       28920042.58
+16384              271469.66       16569193.21
+32768              315876.71        9639792.31
+65536              346490.90        5287031.60
+131072             434503.06        3314995.27
+262144             439699.33        1677319.83
+524288             442204.82         843438.76
+1048576            443371.18         422831.70
+2097152            444086.66         211757.02
+4194304            444422.51         105958.58
+real 8.08
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.75
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.17
+65536                  12.05
+131072                 17.02
+262144                 25.97
+524288                 44.57
+1048576                82.04
+2097152               157.51
+4194304               308.37
+real 2.44
+user 0.15
+sys 0.08
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.13
+user 0.18
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.82
+8                       7.65
+16                      7.94
+32                      7.76
+64                      7.68
+128                     7.90
+256                     9.00
+512                     9.49
+1024                   11.01
+2048                   14.55
+4096                   19.41
+8192                   27.55
+16384                  46.95
+32768                  58.10
+65536                  91.11
+131072                117.32
+262144                477.96
+524288                231.85
+1048576               358.85
+real 1.42
+user 0.18
+sys 0.05
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.93      100930900.28
+2                     205.68      102841446.91
+4                     405.85      101463140.10
+8                     812.38      101547105.86
+16                   1580.94       98808699.03
+32                   3133.72       97928861.95
+64                   6201.21       96893861.01
+128                 12040.58       94067025.51
+256                 21510.81       84026614.45
+512                 40125.32       78369756.01
+1024                71647.00       69967769.73
+2048               114484.20       55900490.58
+4096               177493.18       43333295.25
+8192               237059.91       28937977.63
+16384              270738.47       16524564.56
+32768              316828.81        9668848.09
+65536              346988.58        5294625.62
+131072             434483.45        3314845.62
+262144             439698.78        1677317.72
+524288             442210.18         843448.98
+1048576            443376.93         422837.19
+2097152            444082.23         211754.91
+4194304            444109.60         105883.98
+real 8.06
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.77
+32768                   9.16
+65536                  12.05
+131072                 17.03
+262144                 25.98
+524288                 44.59
+1048576                82.06
+2097152               157.49
+4194304               308.39
+real 2.48
+user 0.18
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.87
+user 0.16
+sys 0.08
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.79
+8                       7.51
+16                      7.48
+32                      7.48
+64                      7.66
+128                     7.93
+256                     8.90
+512                     9.51
+1024                   11.04
+2048                   14.42
+4096                   19.46
+8192                   27.52
+16384                  46.95
+32768                  58.83
+65536                  90.71
+131072                117.33
+262144                475.78
+524288                232.25
+1048576               358.45
+real 1.48
+user 0.24
+sys 0.00
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      99.08       99083717.52
+2                     204.10      102050934.78
+4                     408.38      102095805.55
+8                     814.34      101793058.89
+16                   1567.13       97945347.64
+32                   3119.88       97496371.26
+64                   6217.59       97149828.94
+128                 12020.93       93913549.09
+256                 21446.72       83776247.06
+512                 39966.43       78059430.36
+1024                71770.80       70088668.33
+2048               114640.88       55976992.58
+4096               177065.96       43228994.84
+8192               236705.12       28894667.51
+16384              272067.58       16605687.25
+32768              316745.10        9666293.40
+65536              347160.37        5297246.81
+131072             434503.37        3314997.63
+262144             439702.96        1677333.67
+524288             442208.55         843445.87
+1048576            443351.87         422813.29
+2097152            444081.16         211754.40
+4194304            444300.85         105929.58
+real 8.06
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.16
+65536                  11.97
+131072                 17.07
+262144                 25.98
+524288                 44.58
+1048576                82.07
+2097152               157.51
+4194304               308.37
+real 2.44
+user 0.21
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.11
+user 0.17
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.76
+8                       7.44
+16                      7.45
+32                      7.45
+64                      7.71
+128                     7.89
+256                     8.92
+512                     9.54
+1024                   11.02
+2048                   14.42
+4096                   19.49
+8192                   27.64
+16384                  46.94
+32768                  57.96
+65536                  90.77
+131072                117.13
+262144                475.32
+524288                233.03
+1048576               359.95
+real 1.41
+user 0.19
+sys 0.04
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     101.24      101241793.88
+2                     202.61      101306046.66
+4                     410.40      102600584.14
+8                     814.78      101847831.98
+16                   1579.78       98736243.58
+32                   3112.26       97258017.26
+64                   6234.70       97417207.27
+128                 12042.35       94080853.49
+256                 21464.54       83845872.62
+512                 40011.55       78147566.87
+1024                72060.86       70371936.99
+2048               115071.99       56187497.24
+4096               178003.10       43457788.55
+8192               237093.61       28942091.65
+16384              271322.26       16560196.52
+32768              315936.09        9641604.43
+65536              346572.96        5288283.77
+131072             434450.78        3314596.42
+262144             439695.33        1677304.58
+524288             442194.04         843418.20
+1048576            443384.54         422844.45
+2097152            444085.24         211756.35
+4194304            444080.21         105876.97
+real 8.47
+user 0.22
+sys 0.01
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.76
+4096                    3.41
+8192                    4.90
+16384                   6.79
+32768                   9.15
+65536                  12.01
+131072                 17.00
+262144                 25.98
+524288                 44.55
+1048576                82.05
+2097152               157.47
+4194304               308.35
+real 2.42
+user 0.17
+sys 0.07
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.86
+user 0.18
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.79
+8                       7.61
+16                      7.47
+32                      7.58
+64                      7.68
+128                     8.10
+256                     8.97
+512                     9.55
+1024                   11.07
+2048                   14.43
+4096                   19.39
+8192                   27.56
+16384                  47.48
+32768                  58.21
+65536                  90.89
+131072                116.82
+262144                478.11
+524288                232.32
+1048576               359.12
+real 1.36
+user 0.17
+sys 0.06
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.55      100550622.67
+2                     203.35      101672936.83
+4                     407.16      101790276.25
+8                     812.21      101526566.94
+16                   1556.78       97299048.72
+32                   3116.30       97384225.47
+64                   6175.03       96484851.45
+128                 11985.84       93639380.48
+256                 21523.72       84077012.57
+512                 40178.57       78473777.00
+1024                71914.38       70228885.13
+2048               114687.09       55999553.75
+4096               177310.17       43288615.85
+8192               234475.39       28622484.25
+16384              270901.05       16534487.65
+32768              316988.02        9673706.54
+65536              346399.86        5285642.39
+131072             434499.92        3314971.28
+262144             439723.54        1677412.18
+524288             442186.31         843403.45
+1048576            443376.50         422836.78
+2097152            443913.92         211674.65
+4194304            444097.99         105881.21
+real 8.18
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.16
+65536                  12.04
+131072                 17.05
+262144                 25.97
+524288                 44.60
+1048576                82.02
+2097152               157.48
+4194304               308.39
+real 2.55
+user 0.19
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.85
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.71
+8                       7.45
+16                      7.44
+32                      7.47
+64                      7.66
+128                     7.90
+256                     8.94
+512                     9.51
+1024                   11.09
+2048                   14.46
+4096                   19.40
+8192                   27.53
+16384                  46.94
+32768                  58.00
+65536                  90.88
+131072                116.89
+262144                476.05
+524288                233.03
+1048576               358.03
+real 1.42
+user 0.17
+sys 0.06
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.77      100766425.10
+2                     203.15      101575914.60
+4                     405.43      101358741.65
+8                     816.14      102017078.89
+16                   1576.60       98537526.05
+32                   3100.96       96904864.31
+64                   6207.52       96992521.44
+128                 12000.93       93757267.56
+256                 21440.04       83750141.59
+512                 40096.90       78314255.07
+1024                71688.07       70007879.30
+2048               114297.02       55809091.49
+4096               177005.40       43214208.70
+8192               237815.78       29030246.60
+16384              271770.69       16587566.60
+32768              314567.20        9599829.15
+65536              346822.82        5292096.19
+131072             434476.09        3314789.50
+262144             439705.92        1677344.97
+524288             442212.76         843453.90
+1048576            443372.79         422833.24
+2097152            444078.39         211753.08
+4194304            444412.68         105956.24
+real 8.35
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.79
+32768                   9.15
+65536                  11.99
+131072                 17.05
+262144                 25.97
+524288                 44.56
+1048576                82.05
+2097152               157.48
+4194304               308.37
+real 2.46
+user 0.21
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.88
+user 0.16
+sys 0.07
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.77
+8                       7.43
+16                      7.47
+32                      7.47
+64                      7.64
+128                     7.92
+256                     8.97
+512                     9.54
+1024                   11.05
+2048                   14.44
+4096                   19.51
+8192                   27.71
+16384                  47.36
+32768                  57.96
+65536                  90.72
+131072                117.35
+262144                482.15
+524288                232.92
+1048576               359.09
+real 1.63
+user 0.20
+sys 0.03
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      94.12       94121842.75
+2                     190.12       95060299.24
+4                     377.93       94482638.35
+8                     753.09       94136335.89
+16                   1470.67       91916756.09
+32                   2869.00       89656102.31
+64                   5762.24       90034998.47
+128                 11160.66       87192680.92
+256                 21458.36       83821713.51
+512                 39889.39       77908965.96
+1024                71558.23       69881082.73
+2048               114581.50       55947998.96
+4096               177304.74       43287289.16
+8192               236591.42       28880789.04
+16384              271434.59       16567052.68
+32768              317151.56        9678697.49
+65536              347065.51        5295799.36
+131072             434490.60        3314900.24
+262144             439720.96        1677402.36
+524288             442201.18         843431.82
+1048576            443383.01         422842.99
+2097152            444081.61         211754.61
+4194304            443888.75         105831.33
+real 8.44
+user 0.20
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.95
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.84
+32768                   9.17
+65536                  12.08
+131072                 16.99
+262144                 26.01
+524288                 44.54
+1048576                82.00
+2097152               157.46
+4194304               308.36
+real 2.43
+user 0.18
+sys 0.06
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.80
+user 0.19
+sys 0.05
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.77
+8                       7.38
+16                      7.41
+32                      7.50
+64                      7.64
+128                     7.88
+256                     8.94
+512                     9.53
+1024                   11.08
+2048                   14.52
+4096                   19.42
+8192                   27.54
+16384                  46.94
+32768                  57.97
+65536                  91.51
+131072                119.34
+262144                476.56
+524288                233.03
+1048576               358.24
+real 1.35
+user 0.17
+sys 0.06
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.68      100681863.99
+2                     204.48      102240760.02
+4                     409.11      102278186.68
+8                     816.71      102088833.24
+16                   1574.41       98400322.11
+32                   3116.35       97386031.48
+64                   6221.55       97211713.63
+128                 12022.36       93924704.31
+256                 21316.64       83268110.71
+512                 39958.45       78043843.26
+1024                71729.63       70048466.15
+2048               114567.01       55940923.33
+4096               177444.26       43321351.57
+8192               236916.40       28920459.13
+16384              271142.21       16549207.43
+32768              316246.63        9651081.36
+65536              346877.28        5292927.21
+131072             434525.55        3315166.88
+262144             439712.03        1677368.27
+524288             442196.83         843423.52
+1048576            443367.04         422827.76
+2097152            444087.09         211757.23
+4194304            443619.47         105767.12
+real 8.05
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.79
+32768                   9.15
+65536                  12.02
+131072                 17.06
+262144                 26.01
+524288                 44.57
+1048576                82.03
+2097152               157.51
+4194304               308.37
+real 2.42
+user 0.19
+sys 0.04
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 0.83
+user 0.20
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.89
+8                       7.46
+16                      7.48
+32                      7.45
+64                      7.70
+128                     7.90
+256                     8.93
+512                     9.56
+1024                   11.04
+2048                   14.55
+4096                   19.40
+8192                   27.53
+16384                  46.90
+32768                  58.07
+65536                  90.88
+131072                117.10
+262144                479.67
+524288                234.60
+1048576               358.36
+real 1.62
+user 0.15
+sys 0.08
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 32 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                     100.70      100698002.36
+2                     205.72      102858388.41
+4                     408.68      102170626.94
+8                     811.67      101458817.28
+16                   1560.50       97531240.48
+32                   3124.85       97651453.92
+64                   6227.25       97300805.34
+128                 11843.74       92529256.50
+256                 21503.23       83997010.89
+512                 40152.82       78423473.74
+1024                71910.28       70224887.66
+2048               114462.15       55889720.41
+4096               177694.40       43382422.41
+8192               236793.35       28905438.00
+16384              270804.32       16528584.12
+32768              317112.20        9677496.48
+65536              347192.09        5297730.93
+131072             434509.72        3315046.08
+262144             439691.75        1677290.93
+524288             442199.55         843428.71
+1048576            443370.03         422830.61
+2097152            443900.09         211668.06
+4194304            443930.77         105841.34
+real 8.07
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.84
+32768                   9.16
+65536                  12.06
+131072                 17.06
+262144                 25.99
+524288                 44.56
+1048576                82.06
+2097152               157.50
+4194304               308.38
+real 2.45
+user 0.20
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 64 processes
+real 1.16
+user 0.20
+sys 0.03
+
+time jsrun -n 64 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       7.86
+8                       7.46
+16                      7.50
+32                      7.44
+64                      7.69
+128                     7.94
+256                     8.92
+512                     9.54
+1024                   11.03
+2048                   14.40
+4096                   19.80
+8192                   27.64
+16384                  46.93
+32768                  58.34
+65536                  93.02
+131072                118.30
+262144                476.88
+524288                234.06
+1048576               359.33
+real 1.40
+user 0.21
+sys 0.02
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/lassen_osu_8_nodes.out
+++ b/google/kubecon/hpc/lassen-run1/lassen_osu_8_nodes.out
@@ -1,0 +1,2001 @@
+Number of nodes:  8
+==============
+Start run 1 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.06       14061167.18
+2                      28.77       14383646.69
+4                      57.81       14453330.98
+8                     113.80       14225367.61
+16                    220.65       13790822.32
+32                    436.72       13647648.63
+64                    866.81       13543855.64
+128                  1646.87       12866138.38
+256                  2948.71       11518394.34
+512                  5497.94       10738169.45
+1024                 9502.49        9279776.94
+2048                15101.90        7373972.76
+4096                22694.39        5540621.85
+8192                30315.18        3700583.48
+16384               34675.24        2116408.94
+32768               40654.88        1240688.54
+65536               44312.07         676148.47
+131072              54492.76         415746.76
+262144              55038.65         209955.79
+524288              55311.19         105497.73
+1048576             55440.80          52872.47
+2097152             55520.27          26474.13
+4194304             55557.73          13245.99
+real 5.57
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.15
+1                       1.12
+2                       1.12
+4                       1.12
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.74
+1024                    1.95
+2048                    2.75
+4096                    3.40
+8192                    4.89
+16384                   6.77
+32768                   9.17
+65536                  12.04
+131072                 17.05
+262144                 25.98
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.36
+real 2.57
+user 0.19
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.65
+user 0.22
+sys 0.01
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.98
+8                       3.84
+16                      3.83
+32                      3.86
+64                      3.89
+128                     4.13
+256                     4.54
+512                     4.97
+1024                    6.00
+2048                    7.62
+4096                   11.00
+8192                   16.47
+16384                  25.70
+32768                  33.55
+65536                  50.70
+131072                 68.36
+262144                182.79
+524288                341.71
+1048576               683.88
+real 0.92
+user 0.19
+sys 0.04
+End run 1 of 20
+
+==============
+Start run 2 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.00       14003242.63
+2                      28.84       14418717.30
+4                      54.57       13643001.03
+8                     113.84       14230119.94
+16                    220.44       13777396.03
+32                    433.25       13538934.75
+64                    868.16       13564998.07
+128                  1624.76       12693438.58
+256                  2936.11       11469184.63
+512                  5455.26       10654808.75
+1024                 9457.52        9235858.94
+2048                15032.05        7339870.41
+4096                22684.98        5538325.21
+8192                30279.17        3696187.27
+16384               34699.62        2117896.52
+32768               40609.96        1239317.60
+65536               44341.76         676601.61
+131072              54499.46         415797.92
+262144              55040.18         209961.64
+524288              55313.60         105502.32
+1048576             55440.89          52872.55
+2097152             55519.96          26473.98
+4194304             55557.13          13245.85
+real 5.11
+user 0.19
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.14
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.15
+65536                  12.04
+131072                 17.01
+262144                 25.99
+524288                 44.56
+1048576                82.04
+2097152               157.48
+4194304               308.35
+real 2.44
+user 0.23
+sys 0.01
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.59
+user 0.21
+sys 0.02
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.92
+8                       3.82
+16                      3.82
+32                      3.82
+64                      3.86
+128                     4.12
+256                     4.49
+512                     4.98
+1024                    6.00
+2048                    7.58
+4096                   11.00
+8192                   16.44
+16384                  25.75
+32768                  33.48
+65536                  50.30
+131072                 68.38
+262144                181.89
+524288                335.49
+1048576               688.37
+real 0.94
+user 0.19
+sys 0.05
+End run 2 of 20
+
+==============
+Start run 3 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      13.03       13030503.08
+2                      28.56       14281442.60
+4                      57.88       14470323.97
+8                     113.69       14211603.00
+16                    220.05       13752963.47
+32                    431.00       13468722.05
+64                    865.63       13525536.85
+128                  1649.54       12887026.09
+256                  2914.92       11386416.27
+512                  5447.71       10640062.08
+1024                 9464.94        9243108.56
+2048                14990.40        7319530.68
+4096                22709.29        5544260.09
+8192                30299.55        3698675.82
+16384               34710.73        2118574.64
+32768               40638.83        1240198.62
+65536               44306.57         676064.65
+131072              54499.06         415794.85
+262144              55036.02         209945.75
+524288              55312.37         105499.98
+1048576             55441.45          52873.09
+2097152             55519.97          26473.98
+4194304             55557.77          13246.01
+real 4.87
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.07
+131072                 17.05
+262144                 25.95
+524288                 44.56
+1048576                82.06
+2097152               157.49
+4194304               308.37
+real 2.42
+user 0.19
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.89
+user 0.21
+sys 0.02
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.02
+8                       3.86
+16                      3.84
+32                      3.84
+64                      3.88
+128                     4.13
+256                     4.50
+512                     4.96
+1024                    5.95
+2048                    7.59
+4096                   10.98
+8192                   16.46
+16384                  25.77
+32768                  33.54
+65536                  50.63
+131072                 68.09
+262144                180.97
+524288                337.11
+1048576               683.82
+real 0.95
+user 0.18
+sys 0.05
+End run 3 of 20
+
+==============
+Start run 4 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      13.39       13391460.64
+2                      28.78       14388343.64
+4                      57.75       14437110.59
+8                     112.33       14041253.86
+16                    219.27       13704445.43
+32                    433.10       13534246.40
+64                    868.02       13562777.38
+128                  1634.93       12772927.78
+256                  2944.95       11503720.51
+512                  5461.14       10666288.90
+1024                 9501.38        9278690.54
+2048                15115.26        7380497.21
+4096                22805.85        5567835.48
+8192                30392.17        3709981.47
+16384               34701.30        2117999.20
+32768               40666.41        1241040.39
+65536               44313.67         676172.94
+131072              54490.52         415729.66
+262144              55035.70         209944.52
+524288              55309.18         105493.88
+1048576             55440.33          52872.02
+2097152             55519.24          26473.64
+4194304             55557.27          13245.89
+real 4.89
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.91
+16384                   6.85
+32768                   9.20
+65536                  12.14
+131072                 17.01
+262144                 26.00
+524288                 44.56
+1048576                82.04
+2097152               157.51
+4194304               308.38
+real 2.45
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.59
+user 0.22
+sys 0.01
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.89
+8                       3.82
+16                      3.84
+32                      3.88
+64                      3.89
+128                     4.13
+256                     4.53
+512                     4.96
+1024                    5.95
+2048                    7.64
+4096                   10.97
+8192                   16.46
+16384                  25.80
+32768                  33.57
+65536                  50.61
+131072                 67.54
+262144                184.15
+524288                339.89
+1048576               669.34
+real 0.98
+user 0.18
+sys 0.05
+End run 4 of 20
+
+==============
+Start run 5 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.10       14095488.12
+2                      28.30       14148438.12
+4                      57.74       14433960.40
+8                     114.04       14254810.30
+16                    220.18       13761509.81
+32                    437.79       13680855.57
+64                    853.50       13335903.27
+128                  1649.50       12886753.63
+256                  2913.24       11379836.26
+512                  5478.58       10700346.01
+1024                 9452.96        9231402.78
+2048                15024.44        7336153.74
+4096                22832.28        5574286.51
+8192                30227.16        3689839.05
+16384               34668.78        2116014.64
+32768               40654.66        1240681.80
+65536               44269.55         675499.70
+131072              54498.11         415787.60
+262144              55039.46         209958.89
+524288              55312.86         105500.91
+1048576             55441.15          52872.80
+2097152             55519.83          26473.92
+4194304             55557.57          13245.96
+real 4.88
+user 0.19
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.17
+65536                  12.06
+131072                 17.06
+262144                 25.97
+524288                 44.56
+1048576                82.05
+2097152               157.50
+4194304               308.36
+real 2.47
+user 0.21
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.85
+user 0.21
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.82
+16                      3.83
+32                      3.82
+64                      3.89
+128                     4.12
+256                     4.51
+512                     4.95
+1024                    5.98
+2048                    7.58
+4096                   10.95
+8192                   16.48
+16384                  25.72
+32768                  33.48
+65536                  50.41
+131072                 67.76
+262144                182.90
+524288                339.16
+1048576               681.84
+real 0.96
+user 0.21
+sys 0.02
+End run 5 of 20
+
+==============
+Start run 6 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.04       14043973.00
+2                      28.83       14415063.74
+4                      57.13       14281920.65
+8                     113.96       14245426.44
+16                    220.01       13750510.94
+32                    435.75       13617282.03
+64                    867.05       13547632.90
+128                  1614.51       12613347.68
+256                  2938.03       11476660.69
+512                  5423.78       10593325.54
+1024                 9506.44        9283630.13
+2048                15122.64        7384101.34
+4096                22751.37        5554534.57
+8192                30325.75        3701874.19
+16384               34698.16        2117807.86
+32768               40691.53        1241807.04
+65536               44337.26         676532.88
+131072              54500.91         415808.98
+262144              55037.52         209951.50
+524288              55310.76         105496.91
+1048576             55441.41          52873.05
+2097152             55520.11          26474.05
+4194304             55557.82          13246.02
+real 4.84
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.77
+4096                    3.43
+8192                    4.92
+16384                   6.85
+32768                   9.20
+65536                  12.12
+131072                 17.05
+262144                 26.01
+524288                 44.57
+1048576                82.02
+2097152               157.49
+4194304               308.35
+real 2.43
+user 0.18
+sys 0.06
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.57
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.87
+8                       3.79
+16                      3.83
+32                      3.82
+64                      3.89
+128                     4.11
+256                     4.50
+512                     4.95
+1024                    5.96
+2048                    7.57
+4096                   10.95
+8192                   16.42
+16384                  25.77
+32768                  33.61
+65536                  50.59
+131072                 67.87
+262144                182.21
+524288                339.45
+1048576               702.64
+real 0.97
+user 0.17
+sys 0.06
+End run 6 of 20
+
+==============
+Start run 7 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.22       14224814.30
+2                      28.66       14328604.15
+4                      57.91       14477173.29
+8                     114.55       14318722.46
+16                    219.80       13737362.03
+32                    436.63       13644608.06
+64                    852.85       13325754.31
+128                  1651.48       12902217.82
+256                  2949.13       11520042.62
+512                  5508.59       10758965.14
+1024                 9493.90        9271385.03
+2048                15042.30        7344871.86
+4096                22768.88        5558809.05
+8192                30305.91        3699451.90
+16384               34509.98        2106322.21
+32768               40671.30        1241189.61
+65536               44323.66         676325.40
+131072              54500.84         415808.41
+262144              55036.75         209948.55
+524288              55313.62         105502.37
+1048576             55441.00          52872.66
+2097152             55519.69          26473.85
+4194304             55557.45          13245.93
+real 4.89
+user 0.20
+sys 0.03
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.14
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.77
+32768                   9.16
+65536                  12.07
+131072                 18.79
+262144                 25.98
+524288                 44.57
+1048576                82.06
+2097152               157.54
+4194304               308.40
+real 2.44
+user 0.19
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.85
+user 0.23
+sys 0.01
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.88
+8                       3.79
+16                      3.83
+32                      3.85
+64                      3.91
+128                     4.12
+256                     4.51
+512                     4.96
+1024                    5.97
+2048                    7.60
+4096                   10.98
+8192                   16.48
+16384                  25.73
+32768                  33.57
+65536                  50.55
+131072                 67.69
+262144                181.34
+524288                340.96
+1048576               676.26
+real 0.96
+user 0.20
+sys 0.03
+End run 7 of 20
+
+==============
+Start run 8 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.13       14132449.76
+2                      28.52       14258295.71
+4                      57.73       14431917.99
+8                     113.88       14234772.55
+16                    219.08       13692189.94
+32                    415.07       12970917.78
+64                    832.40       13006279.59
+128                  1631.54       12746414.08
+256                  2879.62       11248519.79
+512                  5419.01       10584005.58
+1024                 9313.93        9095634.56
+2048                15017.83        7332923.91
+4096                22754.76        5555360.25
+8192                30311.80        3700171.09
+16384               34596.12        2111579.49
+32768               40658.43        1240796.72
+65536               44310.77         676128.70
+131072              54498.14         415787.84
+262144              55036.68         209948.27
+524288              55312.83         105500.85
+1048576             55440.75          52872.42
+2097152             55519.74          26473.87
+4194304             55557.53          13245.95
+real 4.91
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.84
+32768                   9.16
+65536                  12.00
+131072                 17.08
+262144                 25.99
+524288                 44.58
+1048576                82.07
+2097152               157.50
+4194304               308.37
+real 2.45
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.56
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.89
+8                       3.92
+16                      3.81
+32                      3.83
+64                      3.90
+128                     4.11
+256                     4.49
+512                     4.96
+1024                    5.97
+2048                    7.60
+4096                   10.98
+8192                   16.46
+16384                  25.66
+32768                  33.47
+65536                  50.53
+131072                 68.59
+262144                182.72
+524288                335.93
+1048576               678.32
+real 0.99
+user 0.19
+sys 0.04
+End run 8 of 20
+
+==============
+Start run 9 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.12       14122789.94
+2                      28.78       14387729.07
+4                      57.62       14404535.63
+8                     114.65       14331387.59
+16                    219.86       13741528.29
+32                    435.05       13595319.39
+64                    862.22       13472110.10
+128                  1628.53       12722924.52
+256                  2935.63       11467288.89
+512                  5381.22       10510187.49
+1024                 9455.78        9234156.57
+2048                14980.32        7314611.74
+4096                22685.74        5538509.73
+8192                30272.71        3695398.68
+16384               34608.07        2112308.82
+32768               40594.96        1238859.94
+65536               44274.33         675572.65
+131072              54487.46         415706.35
+262144              55034.10         209938.44
+524288              55311.92         105499.11
+1048576             55441.03          52872.69
+2097152             55519.56          26473.79
+4194304             55557.37          13245.91
+real 4.87
+user 0.22
+sys 0.01
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.85
+32768                   9.17
+65536                  12.02
+131072                 17.08
+262144                 25.99
+524288                 44.57
+1048576                82.06
+2097152               157.49
+4194304               308.36
+real 2.46
+user 0.17
+sys 0.07
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.83
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.89
+16                      3.82
+32                      3.83
+64                      3.89
+128                     4.11
+256                     4.52
+512                     4.95
+1024                    5.96
+2048                    7.59
+4096                   10.98
+8192                   16.46
+16384                  25.73
+32768                  33.48
+65536                  50.66
+131072                 67.65
+262144                182.62
+524288                339.14
+1048576               703.23
+real 1.07
+user 0.19
+sys 0.05
+End run 9 of 20
+
+==============
+Start run 10 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.21       14207225.71
+2                      28.78       14391247.42
+4                      57.77       14442795.81
+8                     112.77       14096240.98
+16                    219.34       13708900.07
+32                    435.70       13615543.85
+64                    859.80       13434448.55
+128                  1647.04       12867470.58
+256                  2927.28       11434671.62
+512                  5489.95       10722553.51
+1024                 9456.94        9235289.19
+2048                15092.69        7369476.78
+4096                22687.46        5538930.35
+8192                30342.65        3703936.27
+16384               34477.50        2104339.57
+32768               34989.69        1067800.72
+65536               44300.81         675976.77
+131072              54496.92         415778.47
+262144              54634.79         208415.17
+524288              55118.83         105130.83
+1048576             55213.96          52656.14
+2097152             55365.48          26400.32
+4194304             55446.72          13219.53
+real 4.92
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.41
+8192                    4.91
+16384                   6.79
+32768                   9.16
+65536                  12.05
+131072                 17.02
+262144                 25.98
+524288                 44.57
+1048576                82.02
+2097152               157.51
+4194304               308.38
+real 2.43
+user 0.20
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.52
+user 0.18
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.83
+16                      3.81
+32                      3.83
+64                      3.89
+128                     4.11
+256                     4.47
+512                     4.94
+1024                    5.95
+2048                    7.59
+4096                   11.78
+8192                   16.46
+16384                  25.78
+32768                  33.56
+65536                  50.50
+131072                 67.59
+262144                183.14
+524288                341.64
+1048576               682.42
+real 1.08
+user 0.21
+sys 0.02
+End run 10 of 20
+
+==============
+Start run 11 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.08       14083414.52
+2                      28.45       14225707.52
+4                      57.75       14436768.65
+8                     113.35       14169370.47
+16                    219.92       13744981.20
+32                    432.69       13521429.09
+64                    864.48       13507424.33
+128                  1648.44       12878423.16
+256                  2921.83       11413412.99
+512                  5466.93       10677597.86
+1024                 9481.74        9259507.09
+2048                15012.64        7330389.53
+4096                22646.70        5528979.74
+8192                30282.45        3696587.56
+16384               34728.09        2119634.49
+32768               40554.04        1237611.02
+65536               44348.08         676697.99
+131072              54493.50         415752.44
+262144              55037.25         209950.46
+524288              55312.73         105500.65
+1048576             55441.45          52873.09
+2097152             55519.75          26473.88
+4194304             55557.63          13245.97
+real 4.94
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.97
+2048                    2.77
+4096                    3.41
+8192                    4.91
+16384                   6.78
+32768                   9.19
+65536                  12.08
+131072                 17.03
+262144                 26.00
+524288                 44.57
+1048576                82.08
+2097152               157.49
+4194304               308.39
+real 2.45
+user 0.19
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.81
+user 0.18
+sys 0.06
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.93
+8                       3.86
+16                      3.90
+32                      3.83
+64                      3.90
+128                     4.12
+256                     4.51
+512                     4.96
+1024                    5.98
+2048                    7.60
+4096                   10.99
+8192                   16.46
+16384                  25.68
+32768                  33.55
+65536                  50.64
+131072                 68.65
+262144                183.19
+524288                343.11
+1048576               678.77
+real 0.97
+user 0.21
+sys 0.02
+End run 11 of 20
+
+==============
+Start run 12 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.16       14156692.47
+2                      28.81       14406213.58
+4                      57.27       14317705.41
+8                     114.28       14284972.93
+16                    219.72       13732218.52
+32                    435.72       13616398.40
+64                    867.74       13558424.36
+128                  1638.14       12797984.32
+256                  2936.84       11472031.99
+512                  5407.84       10562189.01
+1024                 9474.92        9252853.75
+2048                15035.74        7341672.25
+4096                22792.89        5564669.39
+8192                30223.79        3689426.92
+16384               34658.79        2115404.75
+32768               40730.54        1242997.52
+65536               44303.65         676020.00
+131072              54496.65         415776.45
+262144              55038.76         209956.20
+524288              55312.61         105500.42
+1048576             55441.43          52873.07
+2097152             55520.22          26474.10
+4194304             55557.50          13245.94
+real 4.89
+user 0.18
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.14
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.76
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.16
+65536                  12.05
+131072                 17.07
+262144                 25.97
+524288                 44.56
+1048576                82.04
+2097152               157.47
+4194304               308.40
+real 2.50
+user 0.22
+sys 0.02
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.57
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.83
+16                      3.82
+32                      3.89
+64                      3.87
+128                     4.11
+256                     4.50
+512                     4.95
+1024                    5.97
+2048                    7.57
+4096                   10.96
+8192                   16.42
+16384                  25.77
+32768                  33.50
+65536                  50.63
+131072                 68.16
+262144                182.51
+524288                347.75
+1048576               695.67
+real 0.96
+user 0.17
+sys 0.06
+End run 12 of 20
+
+==============
+Start run 13 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.09       14085839.99
+2                      28.53       14265756.56
+4                      57.03       14256604.40
+8                     114.20       14274506.57
+16                    217.95       13622086.08
+32                    435.97       13624166.72
+64                    815.54       12742784.90
+128                  1650.24       12892503.71
+256                  2930.96       11449057.06
+512                  5491.46       10725513.99
+1024                 9479.65        9257474.60
+2048                15047.11        7347220.15
+4096                22759.17        5556438.22
+8192                30346.36        3704390.24
+16384               34704.41        2118188.81
+32768               40645.11        1240390.43
+65536               44262.84         675397.37
+131072              54497.95         415786.39
+262144              55038.02         209953.40
+524288              55311.59         105498.50
+1048576             55440.70          52872.38
+2097152             55470.26          26450.28
+4194304             55556.76          13245.76
+real 4.90
+user 0.16
+sys 0.07
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.76
+1024                    1.97
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.14
+65536                  12.06
+131072                 17.02
+262144                 25.98
+524288                 44.56
+1048576                82.02
+2097152               157.48
+4194304               308.36
+real 2.42
+user 0.20
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.85
+user 0.16
+sys 0.07
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.97
+8                       3.83
+16                      3.88
+32                      3.82
+64                      3.91
+128                     4.14
+256                     4.50
+512                     4.95
+1024                    5.96
+2048                    7.56
+4096                   10.91
+8192                   16.43
+16384                  25.77
+32768                  33.59
+65536                  50.86
+131072                 68.41
+262144                182.46
+524288                341.18
+1048576               690.29
+real 0.95
+user 0.17
+sys 0.06
+End run 13 of 20
+
+==============
+Start run 14 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.11       14111346.24
+2                      28.92       14461258.80
+4                      57.57       14393108.40
+8                     114.71       14338756.48
+16                    219.94       13746383.52
+32                    435.99       13624630.78
+64                    866.64       13541290.89
+128                  1643.87       12842753.53
+256                  2940.85       11487686.86
+512                  5389.53       10526428.33
+1024                 9425.17        9204266.03
+2048                15066.95        7356907.43
+4096                22768.80        5558788.53
+8192                30315.69        3700645.53
+16384               34693.42        2117518.30
+32768               40655.82        1240717.16
+65536               44309.31         676106.47
+131072              54502.54         415821.39
+262144              55040.09         209961.26
+524288              55312.73         105500.65
+1048576             55441.60          52873.23
+2097152             55520.28          26474.13
+4194304             55557.50          13245.94
+real 4.90
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.13
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.17
+65536                  12.05
+131072                 17.05
+262144                 25.97
+524288                 44.57
+1048576                82.02
+2097152               157.49
+4194304               308.38
+real 2.44
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.59
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.82
+16                      3.93
+32                      3.80
+64                      3.86
+128                     4.12
+256                     4.50
+512                     4.97
+1024                    5.98
+2048                    7.59
+4096                   10.98
+8192                   16.47
+16384                  25.78
+32768                  33.65
+65536                  50.44
+131072                 68.59
+262144                181.79
+524288                334.42
+1048576               680.76
+real 0.96
+user 0.19
+sys 0.04
+End run 14 of 20
+
+==============
+Start run 15 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      13.85       13848317.65
+2                      28.85       14424363.65
+4                      54.43       13608682.34
+8                     114.06       14257620.73
+16                    220.04       13752438.91
+32                    435.46       13608045.76
+64                    866.69       13542043.02
+128                  1632.84       12756532.12
+256                  2939.75       11483409.84
+512                  5449.53       10643609.95
+1024                 9497.81        9275204.37
+2048                15095.48        7370839.00
+4096                22788.40        5563573.72
+8192                30321.04        3701299.36
+16384               34644.28        2114518.87
+32768               40688.11        1241702.66
+65536               44323.86         676328.46
+131072              54505.86         415846.71
+262144              55036.95         209949.30
+524288              55312.91         105501.00
+1048576             55439.93          52871.64
+2097152             55520.16          26474.08
+4194304             55557.50          13245.94
+real 4.88
+user 0.19
+sys 0.04
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.20
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.15
+65536                  12.01
+131072                 17.07
+262144                 25.99
+524288                 44.56
+1048576                82.04
+2097152               157.49
+4194304               308.36
+real 2.46
+user 0.22
+sys 0.01
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.84
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       4.07
+8                       3.83
+16                      3.84
+32                      3.84
+64                      3.92
+128                     4.15
+256                     4.53
+512                     4.97
+1024                    6.01
+2048                    7.61
+4096                   10.97
+8192                   16.45
+16384                  25.71
+32768                  33.59
+65536                  51.32
+131072                 67.59
+262144                182.36
+524288                342.49
+1048576               696.73
+real 0.97
+user 0.18
+sys 0.05
+End run 15 of 20
+
+==============
+Start run 16 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.12       14121605.78
+2                      28.87       14435987.11
+4                      57.60       14399228.74
+8                     114.52       14314791.21
+16                    219.69       13730914.83
+32                    434.43       13575961.22
+64                    869.46       13585384.67
+128                  1651.33       12901027.95
+256                  2941.36       11489697.65
+512                  5436.98       10619106.34
+1024                 9511.59        9288665.98
+2048                15056.61        7351862.13
+4096                22295.98        5443353.72
+8192                30271.70        3695275.46
+16384               34635.29        2113970.42
+32768               40628.15        1239872.82
+65536               44282.13         675691.73
+131072              54489.10         415718.82
+262144              55033.59         209936.48
+524288              54361.03         103685.43
+1048576             55188.08          52631.45
+2097152             55372.02          26403.44
+4194304             55472.62          13225.70
+real 4.95
+user 0.17
+sys 0.06
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.14
+16                      1.16
+32                      1.21
+64                      1.21
+128                     1.32
+256                     1.63
+512                     1.74
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.89
+16384                   6.76
+32768                   9.14
+65536                  12.02
+131072                 17.06
+262144                 25.99
+524288                 44.57
+1048576                82.04
+2097152               157.51
+4194304               308.37
+real 2.46
+user 0.18
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.56
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.87
+8                       3.84
+16                      3.81
+32                      3.84
+64                      3.89
+128                     4.13
+256                     4.50
+512                     4.98
+1024                    5.99
+2048                    7.62
+4096                   11.79
+8192                   16.45
+16384                  25.66
+32768                  34.23
+65536                  50.79
+131072                 68.32
+262144                182.33
+524288                348.39
+1048576               692.64
+real 0.95
+user 0.16
+sys 0.07
+End run 16 of 20
+
+==============
+Start run 17 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.13       14130452.78
+2                      28.83       14413034.79
+4                      57.05       14262100.64
+8                     114.53       14315735.79
+16                    219.98       13748841.96
+32                    437.97       13686531.38
+64                    869.25       13581975.45
+128                  1632.86       12756684.68
+256                  2934.29       11462072.41
+512                  5451.11       10646699.67
+1024                 9477.80        9255660.51
+2048                15096.63        7371403.56
+4096                22811.37        5569182.41
+8192                30313.47        3700374.87
+16384               34713.92        2118769.44
+32768               40607.18        1239232.83
+65536               44347.18         676684.27
+131072              54480.46         415652.95
+262144              55031.07         209926.87
+524288              55308.68         105492.93
+1048576             55440.13          52871.83
+2097152             55519.71          26473.86
+4194304             55557.30          13245.89
+real 4.87
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.91
+16384                   6.78
+32768                   9.16
+65536                  12.02
+131072                 17.07
+262144                 25.98
+524288                 44.56
+1048576                82.05
+2097152               157.48
+4194304               308.35
+real 2.45
+user 0.18
+sys 0.05
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.84
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.91
+8                       3.82
+16                      3.85
+32                      3.82
+64                      3.88
+128                     4.12
+256                     4.50
+512                     4.95
+1024                    5.95
+2048                    7.58
+4096                   10.95
+8192                   16.46
+16384                  25.74
+32768                  33.47
+65536                  50.49
+131072                 68.39
+262144                180.32
+524288                334.96
+1048576               671.22
+real 0.95
+user 0.21
+sys 0.03
+End run 17 of 20
+
+==============
+Start run 18 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.04       14043287.34
+2                      28.84       14421576.48
+4                      57.75       14437444.41
+8                     113.60       14199991.35
+16                    220.47       13779257.37
+32                    435.67       13614805.25
+64                    867.84       13560047.44
+128                  1635.82       12779833.42
+256                  2940.86       11487748.72
+512                  5456.45       10657132.97
+1024                 9510.95        9288035.78
+2048                15068.83        7357827.23
+4096                22622.04        5522958.36
+8192                30327.79        3702122.59
+16384               34683.43        2116908.77
+32768               40618.30        1239572.04
+65536               44291.38         675832.75
+131072              54500.37         415804.81
+262144              55038.81         209956.40
+524288              55312.72         105500.64
+1048576             55441.64          52873.27
+2097152             55519.90          26473.95
+4194304             55557.64          13245.97
+real 4.91
+user 0.22
+sys 0.01
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.75
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.15
+65536                  12.00
+131072                 17.02
+262144                 25.99
+524288                 44.53
+1048576                81.98
+2097152               157.47
+4194304               308.39
+real 2.46
+user 0.19
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.51
+user 0.20
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.89
+8                       3.82
+16                      3.84
+32                      3.83
+64                      3.90
+128                     4.12
+256                     4.49
+512                     4.98
+1024                    5.97
+2048                    7.59
+4096                   10.93
+8192                   16.45
+16384                  25.83
+32768                  33.62
+65536                  50.61
+131072                 67.91
+262144                179.60
+524288                336.42
+1048576               693.13
+real 1.20
+user 0.21
+sys 0.03
+End run 18 of 20
+
+==============
+Start run 19 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.07       14071531.75
+2                      28.60       14300285.89
+4                      57.68       14420869.70
+8                     114.55       14319082.86
+16                    218.75       13671846.84
+32                    437.19       13662164.56
+64                    864.92       13514355.31
+128                  1664.90       13006999.90
+256                  2950.23       11524346.98
+512                  5496.61       10735571.14
+1024                 9484.84        9262539.07
+2048                15127.93        7386683.66
+4096                22795.70        5565355.32
+8192                30331.95        3702630.73
+16384               34624.08        2113286.17
+32768               40639.15        1240208.35
+65536               44325.48         676353.19
+131072              54491.07         415733.85
+262144              55039.33         209958.38
+524288              55312.32         105499.87
+1048576             55441.59          52873.22
+2097152             55520.18          26474.09
+4194304             55548.10          13243.70
+real 4.95
+user 0.21
+sys 0.02
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.16
+1                       1.13
+2                       1.13
+4                       1.13
+8                       1.15
+16                      1.17
+32                      1.21
+64                      1.21
+128                     1.29
+256                     1.63
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.42
+8192                    4.90
+16384                   6.78
+32768                   9.18
+65536                  12.07
+131072                 17.07
+262144                 25.98
+524288                 44.57
+1048576                82.12
+2097152               157.53
+4194304               308.40
+real 2.48
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.80
+user 0.21
+sys 0.02
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.90
+8                       3.89
+16                      3.82
+32                      3.84
+64                      3.88
+128                     4.12
+256                     4.50
+512                     4.94
+1024                    5.97
+2048                    7.59
+4096                   10.96
+8192                   16.45
+16384                  25.79
+32768                  33.70
+65536                  50.54
+131072                 68.73
+262144                183.07
+524288                332.85
+1048576               680.33
+real 0.95
+user 0.17
+sys 0.06
+End run 19 of 20
+
+==============
+Start run 20 of 20
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr
+# OSU MPI Multiple Bandwidth / Message Rate Test v5.8
+# [ pairs: 4 ] [ window size: 64 ]
+# Size                  MB/s        Messages/s
+1                      14.12       14121987.49
+2                      28.70       14352470.90
+4                      57.70       14425054.52
+8                     113.27       14159315.53
+16                    220.43       13776802.88
+32                    436.86       13651928.09
+64                    866.31       13536071.25
+128                  1659.34       12963594.08
+256                  2914.77       11385823.76
+512                  5476.51       10696308.81
+1024                 9491.34        9268890.89
+2048                15077.22        7361925.79
+4096                22703.01        5542727.17
+8192                30352.41        3705127.97
+16384               34671.05        2116153.17
+32768               40731.00        1243011.58
+65536               44306.02         676056.22
+131072              54498.16         415787.94
+262144              55036.04         209945.84
+524288              55312.77         105500.74
+1048576             55438.70          52870.46
+2097152             55366.80          26400.95
+4194304             55357.66          13198.30
+real 4.90
+user 0.18
+sys 0.05
+
+time jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.17
+1                       1.13
+2                       1.14
+4                       1.14
+8                       1.15
+16                      1.17
+32                      1.22
+64                      1.21
+128                     1.30
+256                     1.62
+512                     1.75
+1024                    1.96
+2048                    2.76
+4096                    3.43
+8192                    4.90
+16384                   6.77
+32768                   9.16
+65536                  12.06
+131072                 17.05
+262144                 25.96
+524288                 44.55
+1048576                82.04
+2097152               157.49
+4194304               308.34
+real 2.44
+user 0.20
+sys 0.04
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello
+# OSU MPI Hello World Test v5.8
+This is a test with 8 processes
+real 0.60
+user 0.20
+sys 0.03
+
+time jsrun -n 8 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
+
+# OSU MPI Allreduce Latency Test v5.8
+# Size       Avg Latency(us)
+4                       3.91
+8                       3.82
+16                      3.82
+32                      3.81
+64                      3.88
+128                     4.12
+256                     4.49
+512                     4.95
+1024                    5.98
+2048                    7.66
+4096                   10.97
+8192                   16.45
+16384                  26.66
+32768                  33.65
+65536                  50.80
+131072                 68.50
+262144                182.03
+524288                334.91
+1048576               701.94
+real 0.97
+user 0.18
+sys 0.05
+End run 20 of 20
+

--- a/google/kubecon/hpc/lassen-run1/osu_output.txt
+++ b/google/kubecon/hpc/lassen-run1/osu_output.txt
@@ -1,0 +1,213 @@
+Sat Sep 23 23:54:08 PDT 2023
+lassen582
+JobID is 5223737
+Hosts: 
+logout
+
+------------------------------------------------------------
+Sender: LSF System <lsfadmin@lassen710>
+Subject: Job 5223737: <kubecon_osu_128> in cluster <lassen> Done
+
+Job <kubecon_osu_128> was submitted from host <lassen708> by user <milroy1> in cluster <lassen> at Sat Sep 23 23:11:52 2023
+Job was executed on host(s) <1*lassen710>, in queue <pbatch>, as user <milroy1> in cluster <lassen> at Sat Sep 23 23:53:50 2023
+                            <40*lassen582>
+                            <40*lassen409>
+                            <40*lassen254>
+                            <40*lassen584>
+                            <40*lassen81>
+                            <40*lassen88>
+                            <40*lassen744>
+                            <40*lassen415>
+                            <40*lassen590>
+                            <40*lassen265>
+                            <40*lassen93>
+                            <40*lassen95>
+                            <40*lassen276>
+                            <40*lassen438>
+                            <40*lassen768>
+                            <40*lassen769>
+                            <40*lassen112>
+                            <40*lassen113>
+                            <40*lassen458>
+                            <40*lassen611>
+                            <40*lassen615>
+                            <40*lassen461>
+                            <40*lassen617>
+                            <40*lassen790>
+                            <40*lassen462>
+                            <40*lassen791>
+                            <40*lassen134>
+                            <40*lassen463>
+                            <40*lassen795>
+                            <40*lassen467>
+                            <40*lassen141>
+                            <40*lassen471>
+                            <40*lassen143>
+                            <40*lassen632>
+                            <40*lassen305>
+                            <40*lassen151>
+                            <40*lassen308>
+                            <40*lassen153>
+                            <40*lassen309>
+                            <40*lassen482>
+                            <40*lassen154>
+                            <40*lassen639>
+                            <40*lassen156>
+                            <40*lassen486>
+                            <40*lassen158>
+                            <40*lassen487>
+                            <40*lassen159>
+                            <40*lassen312>
+                            <40*lassen642>
+                            <40*lassen313>
+                            <40*lassen316>
+                            <40*lassen160>
+                            <40*lassen490>
+                            <40*lassen491>
+                            <40*lassen318>
+                            <40*lassen162>
+                            <40*lassen648>
+                            <40*lassen492>
+                            <40*lassen164>
+                            <40*lassen495>
+                            <40*lassen167>
+                            <40*lassen801>
+                            <40*lassen807>
+                            <40*lassen651>
+                            <40*lassen322>
+                            <40*lassen652>
+                            <40*lassen323>
+                            <40*lassen653>
+                            <40*lassen325>
+                            <40*lassen655>
+                            <40*lassen326>
+                            <40*lassen327>
+                            <40*lassen181>
+                            <40*lassen338>
+                            <40*lassen182>
+                            <40*lassen188>
+                            <40*lassen672>
+                            <40*lassen673>
+                            <40*lassen344>
+                            <40*lassen675>
+                            <40*lassen346>
+                            <40*lassen192>
+                            <40*lassen678>
+                            <40*lassen193>
+                            <40*lassen500>
+                            <40*lassen79>
+                            <40*lassen360>
+                            <40*lassen366>
+                            <40*lassen367>
+                            <40*lassen368>
+                            <40*lassen369>
+                            <40*lassen73>
+                            <40*lassen72>
+                            <40*lassen71>
+                            <40*lassen70>
+                            <40*lassen579>
+                            <40*lassen521>
+                            <40*lassen522>
+                            <40*lassen528>
+                            <40*lassen374>
+                            <40*lassen378>
+                            <40*lassen379>
+                            <40*lassen245>
+                            <40*lassen244>
+                            <40*lassen573>
+                            <40*lassen729>
+                            <40*lassen243>
+                            <40*lassen572>
+                            <40*lassen200>
+                            <40*lassen201>
+                            <40*lassen530>
+                            <40*lassen202>
+                            <40*lassen531>
+                            <40*lassen203>
+                            <40*lassen532>
+                            <40*lassen204>
+                            <40*lassen533>
+                            <40*lassen205>
+                            <40*lassen534>
+                            <40*lassen535>
+                            <40*lassen537>
+                            <40*lassen209>
+                            <40*lassen538>
+                            <40*lassen382>
+                            <40*lassen539>
+                            <40*lassen383>
+                            <40*lassen385>
+                            <40*lassen386>
+</g/g12/milroy1> was used as the home directory.
+</g/g12/milroy1/kubecon-2023> was used as the working directory.
+Started at Sat Sep 23 23:53:50 2023
+Terminated at Sun Sep 24 00:17:09 2023
+Results reported at Sun Sep 24 00:17:09 2023
+
+Your job looked like:
+
+------------------------------------------------------------
+# LSBATCH: User input
+#!/bin/bash
+### LSF syntax
+#BSUB -nnodes 128                   #number of nodes
+#BSUB -W 360                    #walltime in minutes
+#BSUB -G ice4hpc                   #account
+#BSUB -e osu_errors.txt             #stderr
+#BSUB -o osu_output.txt             #stdout
+#BSUB -J kubecon_osu_128                    #name of job
+#BSUB -q pbatch                   #queue to use
+
+### Shell scripting
+date; hostname
+echo -n 'JobID is '; echo $LSB_JOBID
+echo "Hosts: $LSB_HOSTS"
+cd /g/g12/milroy1/kubecon-2023
+
+for nnodes in {2..7}
+do
+    echo "Number of nodes: " $(( 2**$nnodes )) > /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+    for i in {1..20}
+    do
+        echo "==============" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        echo "Start run ${i} of 20" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        #echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_ibarrier" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        #{ time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_ibarrier ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_mbw_mr ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n 2 -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/startup/osu_hello ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "\ntime jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+        { time -p jsrun -n $(( 2**$nnodes )) -a 1 -c 1 -r 1 -l cpu-cpu osu-micro-benchmarks-5.8/install/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce ; } >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out 2>&1
+        echo -e "End run ${i} of 20\n" >> /p/gpfs1/milroy1/kubecon/lassen_osu_$(( 2**$nnodes ))_nodes.out
+    done
+done
+
+
+------------------------------------------------------------
+
+Successfully completed.
+
+Resource usage summary:
+
+    CPU time :                                   22.00 sec.
+    Max Memory :                                 125 MB
+    Average Memory :                             89.38 MB
+    Total Requested Memory :                     -
+    Delta Memory :                               -
+    Max Swap :                                   1450 MB
+    Max Processes :                              5
+    Max Threads :                                28
+    Run time :                                   1399 sec.
+    Turnaround time :                            3917 sec.
+
+The output (if any) is above this job summary.
+
+
+
+PS:
+
+Read file <osu_errors.txt> for stderr output of this job.
+


### PR DESCRIPTION
This PR adds data from the 128-node OSU runs on Lassen. Each OSU test was repeated 20 times for comparison with Compute Engine.