### PR TITLE
Add data and scripts for LAMMPS runs on Ruby

### DIFF
--- a/google/kubecon/hpc/README.md
+++ b/google/kubecon/hpc/README.md
@@ -1,7 +1,8 @@
 # OSU Benchmarks on Lassen at LLNL
 
 This is the start to an experimental setup for running OSU Benchmark experiments for Kubecon America, 2023.
-We will be using LSF, which is the scheduler and resource manager on [Lassen](https://hpc.llnl.gov/hardware/compute-platforms/lassen).
+We will be using LSF, which is the scheduler and resource manager on [Lassen](https://hpc.llnl.gov/hardware/compute-platforms/lassen), and Slurm, which is the scheduler and resource manager on [Ruby](https://hpc.llnl.gov/hardware/compute-platforms/ruby).
 
  - [lassen-run1](lassen-run1): Run OSU to compare against GKE and Compute Engine network. The batch script to run the tests is included.
  - [lassen-run2](lassen-run2): Run LAMMPS to compare against GKE and Compute Engine network (and ditto)
+ - [ruby-run1](ruby-run1): Run LAMMPS to compare against GKE, Compute Engine, Lassen network (and ditto)

--- a/google/kubecon/hpc/ruby-run1/build_lammps.sh
+++ b/google/kubecon/hpc/ruby-run1/build_lammps.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+git clone --depth 1 --branch stable_29Sep2021_update2 https://github.com/lammps/lammps.git
+cd ./lammps
+mkdir build bin
+cd build
+cmake ../cmake -DCMAKE_INSTALL_PREFIX:PATH=../bin -DPKG_REAXFF=yes -DBUILD_MPI=yes -DPKG_OPT=yes -DFFT=FFTW3 
+make
+make install

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_1_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_1_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 32 -n 1600 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  16 by 10 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.024 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  40 by 5 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 61.67 out of 16384 (0.38%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 241.4 | 245.2 | 247.3 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4668   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7551   -111.56966   -1.7004036     56153840 
+      60    294.73455   -113.26203    6223.0674     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6835   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0241   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267    9374.9232   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532      10369.1    -111.5866   -1.6987204     56153840 
+Loop time of 59.6456 on 1600 procs for 100 steps with 4980736 atoms
+
+Performance: 0.014 ns/day, 1656.822 hours/ns, 1.677 timesteps/s
+99.6% CPU use with 1600 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 35.895     | 41.11      | 46.248     |  28.0 | 68.92
+Neigh   | 0.53382    | 0.54951    | 0.61208    |   1.4 |  0.92
+Comm    | 0.070305   | 4.9072     | 10.252     |  81.0 |  8.23
+Output  | 0.0041103  | 0.14791    | 0.43542    |  33.7 |  0.25
+Modify  | 12.671     | 12.926     | 13.357     |   3.9 | 21.67
+Other   |            | 0.005054   |            |       |  0.01
+
+Nlocal:        3112.96 ave        3164 max        3048 min
+Histogram: 58 129 76 72 191 228 412 223 157 54
+Nghost:        11791.8 ave       11919 max       11612 min
+Histogram: 148 109 65 76 186 56 70 475 354 61
+Neighs:    1.02708e+06 ave 1.04328e+06 max 1.00543e+06 min
+Histogram: 47 135 73 73 169 231 368 277 164 63
+
+Total # of neighbors = 1.6433275e+09
+Ave neighs/atom = 329.93669
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:00

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_2_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_2_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 32 -n 1600 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  16 by 10 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.026 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  40 by 5 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 61.67 out of 16384 (0.38%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 241.4 | 245.2 | 247.3 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4668   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7551   -111.56966   -1.7004036     56153840 
+      60    294.73455   -113.26203    6223.0674     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6835   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0241   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267    9374.9232   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532      10369.1    -111.5866   -1.6987204     56153840 
+Loop time of 59.7636 on 1600 procs for 100 steps with 4980736 atoms
+
+Performance: 0.014 ns/day, 1660.101 hours/ns, 1.673 timesteps/s
+99.6% CPU use with 1600 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 35.931     | 41.166     | 46.315     |  28.0 | 68.88
+Neigh   | 0.53421    | 0.55194    | 0.63327    |   1.8 |  0.92
+Comm    | 0.070655   | 4.895      | 10.244     |  81.2 |  8.19
+Output  | 0.007741   | 0.14711    | 0.44147    |  33.4 |  0.25
+Modify  | 12.728     | 12.998     | 13.194     |   3.6 | 21.75
+Other   |            | 0.005064   |            |       |  0.01
+
+Nlocal:        3112.96 ave        3164 max        3048 min
+Histogram: 58 129 76 72 191 228 412 223 157 54
+Nghost:        11791.8 ave       11919 max       11612 min
+Histogram: 148 109 65 76 186 56 70 475 354 61
+Neighs:    1.02708e+06 ave 1.04328e+06 max 1.00543e+06 min
+Histogram: 47 135 73 73 169 231 368 277 164 63
+
+Total # of neighbors = 1.6433275e+09
+Ave neighs/atom = 329.93669
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:00

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_3_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_3_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 32 -n 1600 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  16 by 10 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.026 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  40 by 5 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 61.67 out of 16384 (0.38%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 241.4 | 245.2 | 247.3 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4668   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7551   -111.56966   -1.7004036     56153840 
+      60    294.73455   -113.26203    6223.0674     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6835   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0241   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267    9374.9232   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532      10369.1    -111.5866   -1.6987204     56153840 
+Loop time of 59.7651 on 1600 procs for 100 steps with 4980736 atoms
+
+Performance: 0.014 ns/day, 1660.143 hours/ns, 1.673 timesteps/s
+99.6% CPU use with 1600 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 35.975     | 41.197     | 46.35      |  28.0 | 68.93
+Neigh   | 0.53383    | 0.55235    | 0.61797    |   1.7 |  0.92
+Comm    | 0.068955   | 4.9258     | 10.262     |  81.1 |  8.24
+Output  | 0.0054731  | 0.144      | 0.43474    |  34.1 |  0.24
+Modify  | 12.745     | 12.941     | 13.154     |   3.3 | 21.65
+Other   |            | 0.005064   |            |       |  0.01
+
+Nlocal:        3112.96 ave        3164 max        3048 min
+Histogram: 58 129 76 72 191 228 412 223 157 54
+Nghost:        11791.8 ave       11919 max       11612 min
+Histogram: 148 109 65 76 186 56 70 475 354 61
+Neighs:    1.02708e+06 ave 1.04328e+06 max 1.00543e+06 min
+Histogram: 47 135 73 73 169 231 368 277 164 63
+
+Total # of neighbors = 1.6433275e+09
+Ave neighs/atom = 329.93669
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:00

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_4_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_4_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 32 -n 1600 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  16 by 10 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.024 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  40 by 5 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 61.67 out of 16384 (0.38%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 241.4 | 245.2 | 247.3 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4668   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7551   -111.56966   -1.7004036     56153840 
+      60    294.73455   -113.26203    6223.0674     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6835   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0241   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267    9374.9232   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532      10369.1    -111.5866   -1.6987204     56153840 
+Loop time of 59.753 on 1600 procs for 100 steps with 4980736 atoms
+
+Performance: 0.014 ns/day, 1659.807 hours/ns, 1.674 timesteps/s
+99.6% CPU use with 1600 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 35.912     | 41.213     | 46.255     |  27.9 | 68.97
+Neigh   | 0.53401    | 0.55263    | 0.65278    |   1.8 |  0.92
+Comm    | 0.071974   | 4.8845     | 10.175     |  81.3 |  8.17
+Output  | 0.004292   | 0.13746    | 0.42593    |  34.3 |  0.23
+Modify  | 12.759     | 12.96      | 13.175     |   3.0 | 21.69
+Other   |            | 0.005057   |            |       |  0.01
+
+Nlocal:        3112.96 ave        3164 max        3048 min
+Histogram: 58 129 76 72 191 228 412 223 157 54
+Nghost:        11791.8 ave       11919 max       11612 min
+Histogram: 148 109 65 76 186 56 70 475 354 61
+Neighs:    1.02708e+06 ave 1.04328e+06 max 1.00543e+06 min
+Histogram: 47 135 73 73 169 231 368 277 164 63
+
+Total # of neighbors = 1.6433275e+09
+Ave neighs/atom = 329.93669
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:00

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_5_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_1600_5_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 32 -n 1600 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  16 by 10 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.021 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  40 by 5 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 61.67 out of 16384 (0.38%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 241.4 | 245.2 | 247.3 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4668   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7551   -111.56966   -1.7004036     56153840 
+      60    294.73455   -113.26203    6223.0674     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6835   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0241   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267    9374.9232   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532      10369.1    -111.5866   -1.6987204     56153840 
+Loop time of 59.8753 on 1600 procs for 100 steps with 4980736 atoms
+
+Performance: 0.014 ns/day, 1663.204 hours/ns, 1.670 timesteps/s
+99.6% CPU use with 1600 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 35.945     | 41.221     | 46.413     |  27.9 | 68.84
+Neigh   | 0.53395    | 0.55292    | 0.63313    |   1.8 |  0.92
+Comm    | 0.069594   | 4.955      | 10.333     |  80.8 |  8.28
+Output  | 0.0074353  | 0.14855    | 0.44394    |  33.7 |  0.25
+Modify  | 12.742     | 12.993     | 13.249     |   3.7 | 21.70
+Other   |            | 0.005096   |            |       |  0.01
+
+Nlocal:        3112.96 ave        3164 max        3048 min
+Histogram: 58 129 76 72 191 228 412 223 157 54
+Nghost:        11791.8 ave       11919 max       11612 min
+Histogram: 148 109 65 76 186 56 70 475 354 61
+Neighs:    1.02708e+06 ave 1.04328e+06 max 1.00543e+06 min
+Histogram: 47 135 73 73 169 231 368 277 164 63
+
+Total # of neighbors = 1.6433275e+09
+Ave neighs/atom = 329.93669
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:01

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_1_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_1_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 64 -n 3200 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  20 by 10 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.219 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  50 by 8 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 38.27 out of 16384 (0.23%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 162.2 | 164.3 | 167.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833     439.0198   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4669   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2535   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7633   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0366     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.7166   -111.56212    -1.699662     56153840 
+      80    297.77718   -113.27104    8253.0124   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267     9374.986   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.066    -111.5866   -1.6987204     56153840 
+Loop time of 33.6019 on 3200 procs for 100 steps with 4980736 atoms
+
+Performance: 0.026 ns/day, 933.385 hours/ns, 2.976 timesteps/s
+99.6% CPU use with 3200 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 19.029     | 22.688     | 26.173     |  22.3 | 67.52
+Neigh   | 0.33591    | 0.34547    | 0.6116     |   1.4 |  1.03
+Comm    | 0.046497   | 3.1333     | 6.9549     |  60.7 |  9.32
+Output  | 0.0030382  | 0.14814    | 0.3585     |  23.3 |  0.44
+Modify  | 6.8674     | 7.2841     | 7.767      |   6.4 | 21.68
+Other   |            | 0.003017   |            |       |  0.01
+
+Nlocal:        1556.48 ave        1622 max        1513 min
+Histogram: 125 339 432 980 522 294 242 137 39 90
+Nghost:        8496.04 ave        8664 max        8368 min
+Histogram: 134 301 427 674 778 246 134 216 165 125
+Neighs:        542141.0 ave      562360 max      528092 min
+Histogram: 111 291 471 907 559 384 121 217 38 101
+
+Total # of neighbors = 1.7348523e+09
+Ave neighs/atom = 348.31243
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:34

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_2_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_2_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 64 -n 3200 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  20 by 10 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.045 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  50 by 8 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 38.27 out of 16384 (0.23%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 162.2 | 164.3 | 167.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833     439.0198   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4669   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2535   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7633   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0366     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.7166   -111.56212    -1.699662     56153840 
+      80    297.77718   -113.27104    8253.0124   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267     9374.986   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.066    -111.5866   -1.6987204     56153840 
+Loop time of 33.5312 on 3200 procs for 100 steps with 4980736 atoms
+
+Performance: 0.026 ns/day, 931.423 hours/ns, 2.982 timesteps/s
+99.6% CPU use with 3200 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 19.059     | 22.698     | 26.276     |  22.4 | 67.69
+Neigh   | 0.33587    | 0.34531    | 0.39946    |   1.0 |  1.03
+Comm    | 0.048202   | 3.1763     | 7.0444     |  60.7 |  9.47
+Output  | 0.0046906  | 0.1544     | 0.36773    |  23.0 |  0.46
+Modify  | 6.8062     | 7.1547     | 7.7734     |   7.9 | 21.34
+Other   |            | 0.002995   |            |       |  0.01
+
+Nlocal:        1556.48 ave        1622 max        1513 min
+Histogram: 125 339 432 980 522 294 242 137 39 90
+Nghost:        8496.04 ave        8664 max        8368 min
+Histogram: 134 301 427 674 778 246 134 216 165 125
+Neighs:        542141.0 ave      562360 max      528092 min
+Histogram: 111 291 471 907 559 384 121 217 38 101
+
+Total # of neighbors = 1.7348523e+09
+Ave neighs/atom = 348.31243
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:34

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_3_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_3_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 64 -n 3200 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  20 by 10 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.048 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  50 by 8 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 38.27 out of 16384 (0.23%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 162.2 | 164.3 | 167.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833     439.0198   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4669   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2535   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7633   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0366     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.7166   -111.56212    -1.699662     56153840 
+      80    297.77718   -113.27104    8253.0124   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267     9374.986   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.066    -111.5866   -1.6987204     56153840 
+Loop time of 33.5094 on 3200 procs for 100 steps with 4980736 atoms
+
+Performance: 0.026 ns/day, 930.817 hours/ns, 2.984 timesteps/s
+99.6% CPU use with 3200 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 19.09      | 22.711     | 26.174     |  22.4 | 67.78
+Neigh   | 0.33607    | 0.34617    | 0.40451    |   1.2 |  1.03
+Comm    | 0.049684   | 3.1603     | 6.9353     |  60.7 |  9.43
+Output  | 0.010537   | 0.14685    | 0.35341    |  23.3 |  0.44
+Modify  | 6.876      | 7.1419     | 7.5938     |   6.8 | 21.31
+Other   |            | 0.003027   |            |       |  0.01
+
+Nlocal:        1556.48 ave        1622 max        1513 min
+Histogram: 125 339 432 980 522 294 242 137 39 90
+Nghost:        8496.04 ave        8664 max        8368 min
+Histogram: 134 301 427 674 778 246 134 216 165 125
+Neighs:        542141.0 ave      562360 max      528092 min
+Histogram: 111 291 471 907 559 384 121 217 38 101
+
+Total # of neighbors = 1.7348523e+09
+Ave neighs/atom = 348.31243
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:34

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_4_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_4_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 64 -n 3200 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  20 by 10 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.043 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  50 by 8 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 38.27 out of 16384 (0.23%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 162.2 | 164.3 | 167.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833     439.0198   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4669   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2535   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7633   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0366     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.7166   -111.56212    -1.699662     56153840 
+      80    297.77718   -113.27104    8253.0124   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267     9374.986   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.066    -111.5866   -1.6987204     56153840 
+Loop time of 33.6144 on 3200 procs for 100 steps with 4980736 atoms
+
+Performance: 0.026 ns/day, 933.734 hours/ns, 2.975 timesteps/s
+99.6% CPU use with 3200 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 19.099     | 22.737     | 26.287     |  22.4 | 67.64
+Neigh   | 0.33615    | 0.34717    | 0.41041    |   1.3 |  1.03
+Comm    | 0.04596    | 3.1923     | 7.0775     |  60.6 |  9.50
+Output  | 0.0048699  | 0.14916    | 0.35737    |  23.5 |  0.44
+Modify  | 6.8783     | 7.1853     | 7.7893     |   7.3 | 21.38
+Other   |            | 0.003031   |            |       |  0.01
+
+Nlocal:        1556.48 ave        1622 max        1513 min
+Histogram: 125 339 432 980 522 294 242 137 39 90
+Nghost:        8496.04 ave        8664 max        8368 min
+Histogram: 134 301 427 674 778 246 134 216 165 125
+Neighs:        542141.0 ave      562360 max      528092 min
+Histogram: 111 291 471 907 559 384 121 217 38 101
+
+Total # of neighbors = 1.7348523e+09
+Ave neighs/atom = 348.31243
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:34

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_5_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_3200_5_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 64 -n 3200 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  20 by 10 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.047 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  50 by 8 by 8 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 38.27 out of 16384 (0.23%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 162.2 | 164.3 | 167.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833     439.0198   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4669   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2535   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7633   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0366     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.7166   -111.56212    -1.699662     56153840 
+      80    297.77718   -113.27104    8253.0124   -111.57175   -1.6992888     56153840 
+      90     301.6809   -113.28267     9374.986   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.066    -111.5866   -1.6987204     56153840 
+Loop time of 33.6497 on 3200 procs for 100 steps with 4980736 atoms
+
+Performance: 0.026 ns/day, 934.714 hours/ns, 2.972 timesteps/s
+99.6% CPU use with 3200 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 19.119     | 22.74      | 26.278     |  22.4 | 67.58
+Neigh   | 0.3364     | 0.34715    | 0.40257    |   1.2 |  1.03
+Comm    | 0.049325   | 3.1837     | 7.024      |  60.7 |  9.46
+Output  | 0.0077815  | 0.15183    | 0.36229    |  23.1 |  0.45
+Modify  | 6.9226     | 7.2239     | 7.8178     |   7.4 | 21.47
+Other   |            | 0.003027   |            |       |  0.01
+
+Nlocal:        1556.48 ave        1622 max        1513 min
+Histogram: 125 339 432 980 522 294 242 137 39 90
+Nghost:        8496.04 ave        8664 max        8368 min
+Histogram: 134 301 427 674 778 246 134 216 165 125
+Neighs:        542141.0 ave      562360 max      528092 min
+Histogram: 111 291 471 907 559 384 121 217 38 101
+
+Total # of neighbors = 1.7348523e+09
+Ave neighs/atom = 348.31243
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:34

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_1_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_1_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 8 -n 400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 5 by 8 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.013 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  25 by 4 by 4 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 138.19 out of 16384 (0.84%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 617.2 | 622.1 | 627.2 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2551   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7556   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0693     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.6661   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0323   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9229   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.089    -111.5866   -1.6987204     56153840 
+Loop time of 206.902 on 400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.004 ns/day, 5747.264 hours/ns, 0.483 timesteps/s
+99.5% CPU use with 400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 131.83     | 145.22     | 159.04     |  47.3 | 70.19
+Neigh   | 1.4854     | 1.5263     | 1.7412     |   2.6 |  0.74
+Comm    | 0.11615    | 13.575     | 27.32      | 155.1 |  6.56
+Output  | 0.011671   | 0.11372    | 0.32206    |  24.5 |  0.05
+Modify  | 45.965     | 46.448     | 47.426     |   6.1 | 22.45
+Other   |            | 0.01458    |            |       |  0.01
+
+Nlocal:        12451.8 ave       12604 max       12313 min
+Histogram: 16 23 84 34 71 72 32 17 28 23
+Nghost:        24073.9 ave       24377 max       23727 min
+Histogram: 16 0 14 70 61 129 31 31 32 16
+Neighs:    3.74792e+06 ave 3.79284e+06 max 3.70453e+06 min
+Histogram: 16 23 78 24 41 112 38 15 28 25
+
+Total # of neighbors = 1.4991662e+09
+Ave neighs/atom = 300.99291
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:03:30

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_2_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_2_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 8 -n 400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 5 by 8 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.008 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  25 by 4 by 4 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 138.19 out of 16384 (0.84%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 617.2 | 622.1 | 627.2 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2551   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7556   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0693     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.6661   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0323   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9229   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.089    -111.5866   -1.6987204     56153840 
+Loop time of 208.078 on 400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.004 ns/day, 5779.941 hours/ns, 0.481 timesteps/s
+99.5% CPU use with 400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 131.84     | 145.51     | 159.63     |  47.4 | 69.93
+Neigh   | 1.4859     | 1.5343     | 1.6762     |   3.1 |  0.74
+Comm    | 0.12242    | 13.73      | 27.917     | 155.0 |  6.60
+Output  | 0.0014169  | 0.15435    | 0.39817    |  27.9 |  0.07
+Modify  | 46.664     | 47.131     | 48.35      |   6.5 | 22.65
+Other   |            | 0.01488    |            |       |  0.01
+
+Nlocal:        12451.8 ave       12604 max       12313 min
+Histogram: 16 23 84 34 71 72 32 17 28 23
+Nghost:        24073.9 ave       24377 max       23727 min
+Histogram: 16 0 14 70 61 129 31 31 32 16
+Neighs:    3.74792e+06 ave 3.79284e+06 max 3.70453e+06 min
+Histogram: 16 23 78 24 41 112 38 15 28 25
+
+Total # of neighbors = 1.4991662e+09
+Ave neighs/atom = 300.99291
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:03:31

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_3_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_3_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 8 -n 400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 5 by 8 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.007 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  25 by 4 by 4 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 138.19 out of 16384 (0.84%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 617.2 | 622.1 | 627.2 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2551   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7556   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0693     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.6661   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0323   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9229   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.089    -111.5866   -1.6987204     56153840 
+Loop time of 207.786 on 400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.004 ns/day, 5771.820 hours/ns, 0.481 timesteps/s
+99.5% CPU use with 400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 131.91     | 145.52     | 159.48     |  47.4 | 70.03
+Neigh   | 1.4856     | 1.5327     | 1.677      |   3.0 |  0.74
+Comm    | 0.12568    | 13.691     | 27.698     | 155.2 |  6.59
+Output  | 0.0082529  | 0.13112    | 0.36457    |  29.2 |  0.06
+Modify  | 46.514     | 46.898     | 48.174     |   6.7 | 22.57
+Other   |            | 0.01491    |            |       |  0.01
+
+Nlocal:        12451.8 ave       12604 max       12313 min
+Histogram: 16 23 84 34 71 72 32 17 28 23
+Nghost:        24073.9 ave       24377 max       23727 min
+Histogram: 16 0 14 70 61 129 31 31 32 16
+Neighs:    3.74792e+06 ave 3.79284e+06 max 3.70453e+06 min
+Histogram: 16 23 78 24 41 112 38 15 28 25
+
+Total # of neighbors = 1.4991662e+09
+Ave neighs/atom = 300.99291
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:03:31

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_4_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_4_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 8 -n 400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 5 by 8 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.009 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  25 by 4 by 4 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 138.19 out of 16384 (0.84%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 617.2 | 622.1 | 627.2 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2551   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7556   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0693     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.6661   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0323   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9229   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.089    -111.5866   -1.6987204     56153840 
+Loop time of 207.775 on 400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.004 ns/day, 5771.539 hours/ns, 0.481 timesteps/s
+99.5% CPU use with 400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 131.84     | 145.51     | 159.45     |  47.3 | 70.03
+Neigh   | 1.4862     | 1.5333     | 1.6975     |   3.0 |  0.74
+Comm    | 0.12356    | 13.689     | 27.71      | 154.9 |  6.59
+Output  | 0.0061338  | 0.13506    | 0.37274    |  28.5 |  0.07
+Modify  | 46.521     | 46.895     | 48.185     |   6.1 | 22.57
+Other   |            | 0.01488    |            |       |  0.01
+
+Nlocal:        12451.8 ave       12604 max       12313 min
+Histogram: 16 23 84 34 71 72 32 17 28 23
+Nghost:        24073.9 ave       24377 max       23727 min
+Histogram: 16 0 14 70 61 129 31 31 32 16
+Neighs:    3.74792e+06 ave 3.79284e+06 max 3.70453e+06 min
+Histogram: 16 23 78 24 41 112 38 15 28 25
+
+Total # of neighbors = 1.4991662e+09
+Ave neighs/atom = 300.99291
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:03:31

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_5_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_400_5_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 8 -n 400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 5 by 8 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.009 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  25 by 4 by 4 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 138.19 out of 16384 (0.84%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 617.2 | 622.1 | 627.2 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36847   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2551   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7556   -111.56966   -1.7004036     56153840 
+      60    294.73454   -113.26203    6223.0693     -111.562   -1.7000353     56153840 
+      70     294.6656   -113.26178    6861.6661   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0323   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9229   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.089    -111.5866   -1.6987204     56153840 
+Loop time of 207.731 on 400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.004 ns/day, 5770.306 hours/ns, 0.481 timesteps/s
+99.5% CPU use with 400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 131.9      | 145.59     | 159.52     |  47.3 | 70.09
+Neigh   | 1.4863     | 1.5332     | 1.6188     |   3.0 |  0.74
+Comm    | 0.12319    | 13.658     | 27.743     | 154.8 |  6.57
+Output  | 0.0014701  | 0.13646    | 0.35153    |  27.2 |  0.07
+Modify  | 46.461     | 46.796     | 48.042     |   5.5 | 22.53
+Other   |            | 0.01488    |            |       |  0.01
+
+Nlocal:        12451.8 ave       12604 max       12313 min
+Histogram: 16 23 84 34 71 72 32 17 28 23
+Nghost:        24073.9 ave       24377 max       23727 min
+Histogram: 16 0 14 70 61 129 31 31 32 16
+Neighs:    3.74792e+06 ave 3.79284e+06 max 3.70453e+06 min
+Histogram: 16 23 78 24 41 112 38 15 28 25
+
+Total # of neighbors = 1.4991662e+09
+Ave neighs/atom = 300.99291
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:03:31

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_1_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_1_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 128 -n 6400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  25 by 16 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.226 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  64 by 10 by 10 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 20.40 out of 16384 (0.12%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 114.5 | 115.8 | 117.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01984   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4673   -111.58447    -1.701095     56153840 
+      40    300.60956   -113.27964     6382.269   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.8169   -111.56966   -1.7004035     56153840 
+      60    294.73456   -113.26203    6223.0902     -111.562   -1.7000352     56153840 
+      70    294.66562   -113.26178    6861.6861   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0339   -111.57175   -1.6992887     56153840 
+      90    301.68089   -113.28267    9374.9506   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.105    -111.5866   -1.6987204     56153840 
+Loop time of 18.5 on 6400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.047 ns/day, 513.890 hours/ns, 5.405 timesteps/s
+99.6% CPU use with 6400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 10.9       | 12.858     | 14.579     |  13.7 | 69.50
+Neigh   | 0.21849    | 0.22542    | 0.25273    |   0.6 |  1.22
+Comm    | 0.030381   | 1.1418     | 3.7102     |  54.7 |  6.17
+Output  | 0.0015035  | 0.094375   | 0.15492    |  12.1 |  0.51
+Modify  | 3.6485     | 4.179      | 4.803      |  15.0 | 22.59
+Other   |            | 0.001892   |            |       |  0.01
+
+Nlocal:        778.240 ave         801 max         757 min
+Histogram: 30 275 970 958 883 1771 767 408 155 183
+Nghost:        6307.83 ave        6392 max        6248 min
+Histogram: 230 1138 1333 435 676 1183 677 305 279 144
+Neighs:        287951.0 ave      295570 max      280336 min
+Histogram: 34 284 626 1098 947 1586 1056 393 203 173
+
+Total # of neighbors = 1.8428867e+09
+Ave neighs/atom = 370.00289
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:19

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_2_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_2_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 128 -n 6400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  25 by 16 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.082 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  64 by 10 by 10 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 20.40 out of 16384 (0.12%)
+  4980736 atoms
+  replicate CPU = 0.006 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 114.5 | 115.8 | 117.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01984   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4673   -111.58447    -1.701095     56153840 
+      40    300.60956   -113.27964     6382.269   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.8169   -111.56966   -1.7004035     56153840 
+      60    294.73456   -113.26203    6223.0902     -111.562   -1.7000352     56153840 
+      70    294.66562   -113.26178    6861.6861   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0339   -111.57175   -1.6992887     56153840 
+      90    301.68089   -113.28267    9374.9506   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.105    -111.5866   -1.6987204     56153840 
+Loop time of 18.5874 on 6400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.046 ns/day, 516.318 hours/ns, 5.380 timesteps/s
+99.6% CPU use with 6400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 10.891     | 12.861     | 14.611     |  13.7 | 69.19
+Neigh   | 0.21847    | 0.22564    | 0.25657    |   0.8 |  1.21
+Comm    | 0.030325   | 1.1479     | 3.7512     |  54.6 |  6.18
+Output  | 0.0015116  | 0.097768   | 0.15704    |  11.9 |  0.53
+Modify  | 3.6925     | 4.2531     | 4.844      |  14.8 | 22.88
+Other   |            | 0.001893   |            |       |  0.01
+
+Nlocal:        778.240 ave         801 max         757 min
+Histogram: 30 275 970 958 883 1771 767 408 155 183
+Nghost:        6307.83 ave        6392 max        6248 min
+Histogram: 230 1138 1333 435 676 1183 677 305 279 144
+Neighs:        287951.0 ave      295570 max      280336 min
+Histogram: 34 284 626 1098 947 1586 1056 393 203 173
+
+Total # of neighbors = 1.8428867e+09
+Ave neighs/atom = 370.00289
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:19

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_3_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_3_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 128 -n 6400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  25 by 16 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.096 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  64 by 10 by 10 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 20.40 out of 16384 (0.12%)
+  4980736 atoms
+  replicate CPU = 0.006 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 114.5 | 115.8 | 117.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01984   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4673   -111.58447    -1.701095     56153840 
+      40    300.60956   -113.27964     6382.269   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.8169   -111.56966   -1.7004035     56153840 
+      60    294.73456   -113.26203    6223.0902     -111.562   -1.7000352     56153840 
+      70    294.66562   -113.26178    6861.6861   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0339   -111.57175   -1.6992887     56153840 
+      90    301.68089   -113.28267    9374.9506   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.105    -111.5866   -1.6987204     56153840 
+Loop time of 18.58 on 6400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.047 ns/day, 516.110 hours/ns, 5.382 timesteps/s
+99.6% CPU use with 6400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 10.913     | 12.863     | 14.597     |  13.8 | 69.23
+Neigh   | 0.21872    | 0.22554    | 0.25826    |   0.7 |  1.21
+Comm    | 0.032238   | 1.1536     | 3.7154     |  54.5 |  6.21
+Output  | 0.0018079  | 0.096888   | 0.15702    |  12.0 |  0.52
+Modify  | 3.7152     | 4.2393     | 4.8605     |  14.8 | 22.82
+Other   |            | 0.001888   |            |       |  0.01
+
+Nlocal:        778.240 ave         801 max         757 min
+Histogram: 30 275 970 958 883 1771 767 408 155 183
+Nghost:        6307.83 ave        6392 max        6248 min
+Histogram: 230 1138 1333 435 676 1183 677 305 279 144
+Neighs:        287951.0 ave      295570 max      280336 min
+Histogram: 34 284 626 1098 947 1586 1056 393 203 173
+
+Total # of neighbors = 1.8428867e+09
+Ave neighs/atom = 370.00289
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:19

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_4_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_4_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 128 -n 6400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  25 by 16 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.173 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  64 by 10 by 10 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 20.40 out of 16384 (0.12%)
+  4980736 atoms
+  replicate CPU = 0.006 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 114.5 | 115.8 | 117.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01984   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4673   -111.58447    -1.701095     56153840 
+      40    300.60956   -113.27964     6382.269   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.8169   -111.56966   -1.7004035     56153840 
+      60    294.73456   -113.26203    6223.0902     -111.562   -1.7000352     56153840 
+      70    294.66562   -113.26178    6861.6861   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0339   -111.57175   -1.6992887     56153840 
+      90    301.68089   -113.28267    9374.9506   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.105    -111.5866   -1.6987204     56153840 
+Loop time of 18.5835 on 6400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.046 ns/day, 516.209 hours/ns, 5.381 timesteps/s
+99.6% CPU use with 6400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 10.886     | 12.863     | 14.629     |  13.8 | 69.21
+Neigh   | 0.21843    | 0.22553    | 0.25996    |   0.7 |  1.21
+Comm    | 0.030828   | 1.1557     | 3.7743     |  54.7 |  6.22
+Output  | 0.012409   | 0.10799    | 0.16939    |  11.3 |  0.58
+Modify  | 3.6776     | 4.2299     | 4.8434     |  15.0 | 22.76
+Other   |            | 0.001894   |            |       |  0.01
+
+Nlocal:        778.240 ave         801 max         757 min
+Histogram: 30 275 970 958 883 1771 767 408 155 183
+Nghost:        6307.83 ave        6392 max        6248 min
+Histogram: 230 1138 1333 435 676 1183 677 305 279 144
+Neighs:        287951.0 ave      295570 max      280336 min
+Histogram: 34 284 626 1098 947 1586 1056 393 203 173
+
+Total # of neighbors = 1.8428867e+09
+Ave neighs/atom = 370.00289
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:19

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_5_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_6400_5_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 128 -n 6400 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  25 by 16 by 16 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.083 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  64 by 10 by 10 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 20.40 out of 16384 (0.12%)
+  4980736 atoms
+  replicate CPU = 0.006 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 114.5 | 115.8 | 117.4 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01984   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36846   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4673   -111.58447    -1.701095     56153840 
+      40    300.60956   -113.27964     6382.269   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.8169   -111.56966   -1.7004035     56153840 
+      60    294.73456   -113.26203    6223.0902     -111.562   -1.7000352     56153840 
+      70    294.66562   -113.26178    6861.6861   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0339   -111.57175   -1.6992887     56153840 
+      90    301.68089   -113.28267    9374.9506   -111.58372   -1.6989575     56153840 
+     100    302.58671   -113.28532    10369.105    -111.5866   -1.6987204     56153840 
+Loop time of 18.5366 on 6400 procs for 100 steps with 4980736 atoms
+
+Performance: 0.047 ns/day, 514.905 hours/ns, 5.395 timesteps/s
+99.6% CPU use with 6400 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 10.911     | 12.862     | 14.564     |  13.8 | 69.39
+Neigh   | 0.2187     | 0.2256     | 0.25466    |   0.7 |  1.22
+Comm    | 0.033122   | 1.1526     | 3.6848     |  54.5 |  6.22
+Output  | 0.0028467  | 0.093986   | 0.15432    |  12.1 |  0.51
+Modify  | 3.6901     | 4.2006     | 4.8235     |  14.8 | 22.66
+Other   |            | 0.001884   |            |       |  0.01
+
+Nlocal:        778.240 ave         801 max         757 min
+Histogram: 30 275 970 958 883 1771 767 408 155 183
+Nghost:        6307.83 ave        6392 max        6248 min
+Histogram: 230 1138 1333 435 676 1183 677 305 279 144
+Neighs:        287951.0 ave      295570 max      280336 min
+Histogram: 34 284 626 1098 947 1586 1056 393 203 173
+
+Total # of neighbors = 1.8428867e+09
+Ave neighs/atom = 370.00289
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:19

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_1_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_1_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 16 -n 800 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 8 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.016 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  32 by 5 by 5 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 77.42 out of 16384 (0.47%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 383.5 | 385.1 | 386.9 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36848   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7848   -111.56966   -1.7004035     56153840 
+      60    294.73454   -113.26203    6223.0669     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6805   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0766   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9612   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.049    -111.5866   -1.6987205     56153840 
+Loop time of 108.17 on 800 procs for 100 steps with 4980736 atoms
+
+Performance: 0.008 ns/day, 3004.714 hours/ns, 0.924 timesteps/s
+99.6% CPU use with 800 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 68.748     | 76.636     | 83.768     |  30.2 | 70.85
+Neigh   | 0.87856    | 0.90193    | 0.95716    |   1.9 |  0.83
+Comm    | 0.096952   | 6.5338     | 15.121     | 104.5 |  6.04
+Output  | 0.0016415  | 0.10504    | 0.17701    |  15.9 |  0.10
+Modify  | 23.338     | 23.983     | 24.419     |   7.8 | 22.17
+Other   |            | 0.009918   |            |       |  0.01
+
+Nlocal:        6225.92 ave        6289 max        6159 min
+Histogram: 26 34 79 133 107 101 157 73 37 53
+Nghost:        16712.2 ave       16861 max       16550 min
+Histogram: 55 48 47 58 114 183 108 102 54 31
+Neighs:    1.95632e+06 ave 1.97515e+06 max 1.93646e+06 min
+Histogram: 26 31 101 119 103 107 159 66 35 53
+
+Total # of neighbors = 1.5650549e+09
+Ave neighs/atom = 314.22161
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:50

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_2_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_2_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 16 -n 800 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 8 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.015 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  32 by 5 by 5 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 77.42 out of 16384 (0.47%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 383.5 | 385.1 | 386.9 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36848   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7848   -111.56966   -1.7004035     56153840 
+      60    294.73454   -113.26203    6223.0669     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6805   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0766   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9612   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.049    -111.5866   -1.6987205     56153840 
+Loop time of 108.427 on 800 procs for 100 steps with 4980736 atoms
+
+Performance: 0.008 ns/day, 3011.862 hours/ns, 0.922 timesteps/s
+99.6% CPU use with 800 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 68.796     | 76.793     | 83.914     |  30.2 | 70.82
+Neigh   | 0.87825    | 0.90661    | 1.0621     |   2.4 |  0.84
+Comm    | 0.096955   | 6.6303     | 15.22      | 104.0 |  6.11
+Output  | 0.0016139  | 0.084699   | 0.18531    |  18.5 |  0.08
+Modify  | 23.448     | 24.002     | 24.727     |   7.5 | 22.14
+Other   |            | 0.009932   |            |       |  0.01
+
+Nlocal:        6225.92 ave        6289 max        6159 min
+Histogram: 26 34 79 133 107 101 157 73 37 53
+Nghost:        16712.2 ave       16861 max       16550 min
+Histogram: 55 48 47 58 114 183 108 102 54 31
+Neighs:    1.95632e+06 ave 1.97515e+06 max 1.93646e+06 min
+Histogram: 26 31 101 119 103 107 159 66 35 53
+
+Total # of neighbors = 1.5650549e+09
+Ave neighs/atom = 314.22161
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:50

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_3_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_3_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 16 -n 800 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 8 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.016 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  32 by 5 by 5 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 77.42 out of 16384 (0.47%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 383.5 | 385.1 | 386.9 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36848   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7848   -111.56966   -1.7004035     56153840 
+      60    294.73454   -113.26203    6223.0669     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6805   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0766   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9612   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.049    -111.5866   -1.6987205     56153840 
+Loop time of 108.659 on 800 procs for 100 steps with 4980736 atoms
+
+Performance: 0.008 ns/day, 3018.303 hours/ns, 0.920 timesteps/s
+99.6% CPU use with 800 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 68.8       | 76.794     | 84.027     |  30.2 | 70.67
+Neigh   | 0.87878    | 0.90668    | 0.96416    |   2.3 |  0.83
+Comm    | 0.099342   | 6.6597     | 15.33      | 104.1 |  6.13
+Output  | 0.0012755  | 0.10134    | 0.20179    |  18.3 |  0.09
+Modify  | 23.57      | 24.187     | 24.931     |   8.3 | 22.26
+Other   |            | 0.01009    |            |       |  0.01
+
+Nlocal:        6225.92 ave        6289 max        6159 min
+Histogram: 26 34 79 133 107 101 157 73 37 53
+Nghost:        16712.2 ave       16861 max       16550 min
+Histogram: 55 48 47 58 114 183 108 102 54 31
+Neighs:    1.95632e+06 ave 1.97515e+06 max 1.93646e+06 min
+Histogram: 26 31 101 119 103 107 159 66 35 53
+
+Total # of neighbors = 1.5650549e+09
+Ave neighs/atom = 314.22161
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:50

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_4_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_4_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 16 -n 800 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 8 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.013 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  32 by 5 by 5 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 77.42 out of 16384 (0.47%)
+  4980736 atoms
+  replicate CPU = 0.005 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 383.5 | 385.1 | 386.9 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36848   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7848   -111.56966   -1.7004035     56153840 
+      60    294.73454   -113.26203    6223.0669     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6805   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0766   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9612   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.049    -111.5866   -1.6987205     56153840 
+Loop time of 108.322 on 800 procs for 100 steps with 4980736 atoms
+
+Performance: 0.008 ns/day, 3008.938 hours/ns, 0.923 timesteps/s
+99.6% CPU use with 800 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 68.934     | 76.812     | 83.848     |  30.2 | 70.91
+Neigh   | 0.87899    | 0.90647    | 0.96407    |   2.3 |  0.84
+Comm    | 0.099183   | 6.566      | 15.015     | 104.4 |  6.06
+Output  | 0.0013261  | 0.087854   | 0.17261    |  18.1 |  0.08
+Modify  | 23.404     | 23.94      | 24.766     |   7.3 | 22.10
+Other   |            | 0.01011    |            |       |  0.01
+
+Nlocal:        6225.92 ave        6289 max        6159 min
+Histogram: 26 34 79 133 107 101 157 73 37 53
+Nghost:        16712.2 ave       16861 max       16550 min
+Histogram: 55 48 47 58 114 183 108 102 54 31
+Neighs:    1.95632e+06 ave 1.97515e+06 max 1.93646e+06 min
+Histogram: 26 31 101 119 103 107 159 66 35 53
+
+Total # of neighbors = 1.5650549e+09
+Ave neighs/atom = 314.22161
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:50

--- a/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_5_ranks.out
+++ b/google/kubecon/hpc/ruby-run1/data/ruby_lammps_800_5_ranks.out
@@ -1,0 +1,82 @@
+
+srun -N 16 -n 800 --cpus-per-task=1 --ntasks-per-node=50 /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp -v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+  10 by 8 by 10 MPI processor grid
+  reading atoms ...
+  304 atoms
+  reading velocities ...
+  304 velocities
+  read_data CPU = 0.013 seconds
+Replicating atoms ...
+  triclinic box = (0.0000000 0.0000000 0.0000000) to (1428.8640 178.25920 220.46346) with tilt (0.0000000 -80.416480 0.0000000)
+  32 by 5 by 5 MPI processor grid
+  bounding box image = (0 -1 -1) to (0 1 1)
+  bounding box extra memory = 0.03 MB
+  average # of replicas added to proc = 77.42 out of 16384 (0.47%)
+  4980736 atoms
+  replicate CPU = 0.004 seconds
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 11
+  ghost atom cutoff = 11
+  binsize = 5.5, bins = 275 33 41
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: full/ghost/bin/3d
+      bin: standard
+  (2) fix qeq/reax, perpetual, copy from (1)
+      attributes: half, newton off, ghost
+      pair build: copy
+      stencil: none
+      bin: none
+Setting up Verlet run ...
+  Unit style    : real
+  Current step  : 0
+  Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 383.5 | 385.1 | 386.9 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume 
+       0          300   -113.27833    439.01979   -111.57687   -1.7014647     56153840 
+      10    300.78686   -113.28051    827.36848   -111.57907   -1.7014353     56153840 
+      20    302.44845   -113.28532    1713.1411   -111.58399   -1.7013238     56153840 
+      30    302.57357   -113.28556    4309.4667   -111.58447    -1.701095     56153840 
+      40    300.60957   -113.27964    6382.2543   -111.57887   -1.7007685     56153840 
+      50    297.41258   -113.27006    6487.7848   -111.56966   -1.7004035     56153840 
+      60    294.73454   -113.26203    6223.0669     -111.562   -1.7000353     56153840 
+      70    294.66561   -113.26178    6861.6805   -111.56212   -1.6996621     56153840 
+      80    297.77718   -113.27104    8253.0766   -111.57175   -1.6992887     56153840 
+      90     301.6809   -113.28267    9374.9612   -111.58372   -1.6989574     56153840 
+     100    302.58671   -113.28532    10369.049    -111.5866   -1.6987205     56153840 
+Loop time of 108.37 on 800 procs for 100 steps with 4980736 atoms
+
+Performance: 0.008 ns/day, 3010.265 hours/ns, 0.923 timesteps/s
+99.6% CPU use with 800 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 68.838     | 76.805     | 83.906     |  30.2 | 70.87
+Neigh   | 0.87861    | 0.9066     | 0.96404    |   2.3 |  0.84
+Comm    | 0.098006   | 6.583      | 15.167     | 104.4 |  6.07
+Output  | 0.001277   | 0.093674   | 0.18064    |  17.0 |  0.09
+Modify  | 23.397     | 23.971     | 24.671     |   7.7 | 22.12
+Other   |            | 0.01013    |            |       |  0.01
+
+Nlocal:        6225.92 ave        6289 max        6159 min
+Histogram: 26 34 79 133 107 101 157 73 37 53
+Nghost:        16712.2 ave       16861 max       16550 min
+Histogram: 55 48 47 58 114 183 108 102 54 31
+Neighs:    1.95632e+06 ave 1.97515e+06 max 1.93646e+06 min
+Histogram: 26 31 101 119 103 107 159 66 35 53
+
+Total # of neighbors = 1.5650549e+09
+Ave neighs/atom = 314.22161
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:01:50

--- a/google/kubecon/hpc/ruby-run1/srun_lammps.sh
+++ b/google/kubecon/hpc/ruby-run1/srun_lammps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH -N 128
+#SBATCH -J lammps
+#SBATCH -t 02:00:00
+#SBATCH -p pbatch
+#SBATCH --mail-type=ALL
+#SBATCH -A cnvgdcmp
+
+cd /g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/examples/reaxff/HNS/
+
+lammps=/g/g12/milroy1/kubecon-2023/lammps_ruby/lammps/bin/bin/lmp
+problem="-v x 64 -v y 16 -v z 16 -in in.reaxc.hns -nocite"
+
+output=/p/lustre1/milroy1/kubecon-2023/lammps_ruby
+
+for ranks in 400 800 1600 3200 6400
+do
+    for i in {1..5}
+    do
+        outfile=${output}/ruby_lammps_${ranks}_${i}_ranks.out
+        echo -e "\nsrun -N $(( $ranks/50 )) -n $ranks --cpus-per-task=1 --ntasks-per-node=50 ${lammps} ${problem}" >> ${outfile}
+        srun -N $(( $ranks/50 )) -n $ranks --cpus-per-task=1 --ntasks-per-node=50 ${lammps} ${problem} 2>&1 >> ${outfile}
+    done
+done
+


### PR DESCRIPTION
This PR adds the Slurm `sbatch` script to run LAMMPS with the same configuration as we ran on GKE and Lassen as well as the output data from the LAMMPS runs.