### PR TITLE
Testing new algorithm: adjust bounds based on max cost/core then randomize

### DIFF
--- a/aws/spot-instances/run2/README.md
+++ b/aws/spot-instances/run2/README.md
@@ -125,3 +125,10 @@ Calculating remainder of results (total {args.results})
 ```
 
 Maybe we didn't solve the spot instance problem, but this is some start. I'm pretty proud of myself for doing linear programming! 😆️
+
+### Optimization Tests
+
+ - [spot-instances-choices.json](spot-instances-choices.json): instead removes the most expensive (by core hour) first.
+ - [spot-instance-choices-decrement-bound-by-one.json](spot-instance-choices-decrement-bound-by-one.json) Simply looped through the counts, and always found the first coefficient that was optimized and decreased by one.
+ 
+For the first, we fall back to an approach that removes the cheapest instead. We could also allow the algorithm to select removing one at random!

--- a/aws/spot-instances/run2/README.md
+++ b/aws/spot-instances/run2/README.md
@@ -128,7 +128,7 @@ Maybe we didn't solve the spot instance problem, but this is some start. I'm pre
 
 ### Optimization Tests
 
- - [spot-instances-choices.json](spot-instances-choices.json): instead removes the most expensive (by core hour) first.
+ - [spot-instances-choices.json](spot-instances-choices.json): instead removes the most expensive (by core hour) first and then if reaches local solution, randomizes the original bounds to explore other spaces (this is cool)!
  - [spot-instance-choices-decrement-bound-by-one.json](spot-instance-choices-decrement-bound-by-one.json) Simply looped through the counts, and always found the first coefficient that was optimized and decreased by one.
  
 For the first, we fall back to an approach that removes the cheapest instead. We could also allow the algorithm to select removing one at random!

--- a/aws/spot-instances/run2/README.md
+++ b/aws/spot-instances/run2/README.md
@@ -12,7 +12,15 @@ are in my research notes (private) but I'll show usage here. Note that you need 
 The [spot_instances.py](spot_instances.py) can be used to generate data:
 
 ```bash
-$ python spot_instances.py gen
+python spot_instances.py gen
+```
+
+Note that the prices API seems to have an issue with other regions, and I'll look at later.
+Here is what I was trying (but it wasn't successful to get prices).
+
+```bash
+mkdir -p ./prices
+python spot_instances.py gen --data ./prices/aws-instances-us-west-2.csv --region us-west-2 --no-cache
 ```
 
 That will generate the data file [instances-aws.csv](instances-aws.csv) that we derive current spot prices for.
@@ -132,3 +140,21 @@ Maybe we didn't solve the spot instance problem, but this is some start. I'm pre
  - [spot-instance-choices-decrement-bound-by-one.json](spot-instance-choices-decrement-bound-by-one.json) Simply looped through the counts, and always found the first coefficient that was optimized and decreased by one.
  
 For the first, we fall back to an approach that removes the cheapest instead. We could also allow the algorithm to select removing one at random!
+
+
+### Test Runs
+
+I decided to do some test runs for different zones and sizes (again to mimic hpc6a and hpc7g).  This was done around 11:30am on a Wednesday. Note that the us-east-2 isn't perfect because prices (from the cache) are technically from us-east-1.
+
+```console
+mkdir -p tests/512
+mkdir -p tests/768
+python test_optimize.py 512 --results 50 --outfile ./tests/512/spot-choices-us-east-2.json --region us-east-2
+python test_optimize.py 512 --results 50 --outfile ./tests/512/spot-choices-us-east-1.json --region us-east-1
+python test_optimize.py 768 --results 30 --outfile ./tests/768/spot-choices-us-east-2.json --region us-east-2
+python test_optimize.py 768 --results 50 --outfile ./tests/768/spot-choices-us-east-1.json --region us-east-1
+
+# These didn't work because I couldn't get prices for the west zones, not sure why, but probably OK.
+python test_optimize.py 512 --results 30 --outfile ./tests/512/spot-choices-us-west-1.json --region us-west-1
+python test_optimize.py 512 --results 50 --outfile ./tests/512/spot-choices-us-west-2.json --region us-west-2
+```

--- a/aws/spot-instances/run2/spot-instance-choices-decrement-bound-by-one.json
+++ b/aws/spot-instances/run2/spot-instance-choices-decrement-bound-by-one.json
@@ -1,0 +1,4210 @@
+[
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 128,
+                "total_cores": 512,
+                "cost_per_instance": 3.09,
+                "instances_cost": 12.36,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 12.36
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 14.04
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 16.39
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.97
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 20.21
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 20.439999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 8,
+                "size": 36,
+                "total_cores": 288,
+                "cost_per_instance": 1.48,
+                "instances_cost": 11.84,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            }
+        ],
+        "total_count": 25,
+        "total_cost": 20.77
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 18,
+                "total_cores": 54,
+                "cost_per_instance": 0.79,
+                "instances_cost": 2.37,
+                "available": 3
+            },
+            {
+                "count": 10,
+                "size": 36,
+                "total_cores": 360,
+                "cost_per_instance": 1.48,
+                "instances_cost": 14.8,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 20.99
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 18,
+                "total_cores": 90,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.95,
+                "available": 3
+            },
+            {
+                "count": 9,
+                "size": 36,
+                "total_cores": 324,
+                "cost_per_instance": 1.48,
+                "instances_cost": 13.32,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 21.09
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 10,
+                "size": 18,
+                "total_cores": 180,
+                "cost_per_instance": 0.79,
+                "instances_cost": 7.9,
+                "available": 3
+            },
+            {
+                "count": 9,
+                "size": 36,
+                "total_cores": 324,
+                "cost_per_instance": 1.48,
+                "instances_cost": 13.32,
+                "available": 3
+            }
+        ],
+        "total_count": 27,
+        "total_cost": 21.62
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 12,
+                "size": 18,
+                "total_cores": 216,
+                "cost_per_instance": 0.79,
+                "instances_cost": 9.48,
+                "available": 3
+            },
+            {
+                "count": 8,
+                "size": 36,
+                "total_cores": 288,
+                "cost_per_instance": 1.48,
+                "instances_cost": 11.84,
+                "available": 3
+            }
+        ],
+        "total_count": 28,
+        "total_cost": 21.72
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 14,
+                "size": 18,
+                "total_cores": 252,
+                "cost_per_instance": 0.79,
+                "instances_cost": 11.06,
+                "available": 3
+            },
+            {
+                "count": 7,
+                "size": 36,
+                "total_cores": 252,
+                "cost_per_instance": 1.48,
+                "instances_cost": 10.36,
+                "available": 3
+            }
+        ],
+        "total_count": 29,
+        "total_cost": 21.82
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 16,
+                "size": 18,
+                "total_cores": 288,
+                "cost_per_instance": 0.79,
+                "instances_cost": 12.64,
+                "available": 3
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            }
+        ],
+        "total_count": 30,
+        "total_cost": 21.92
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 18,
+                "size": 18,
+                "total_cores": 324,
+                "cost_per_instance": 0.79,
+                "instances_cost": 14.22,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 36,
+                "total_cores": 180,
+                "cost_per_instance": 1.48,
+                "instances_cost": 7.4,
+                "available": 3
+            }
+        ],
+        "total_count": 31,
+        "total_cost": 22.020000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 19,
+                "size": 18,
+                "total_cores": 342,
+                "cost_per_instance": 0.79,
+                "instances_cost": 15.010000000000002,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 36,
+                "total_cores": 144,
+                "cost_per_instance": 1.48,
+                "instances_cost": 5.92,
+                "available": 3
+            }
+        ],
+        "total_count": 49,
+        "total_cost": 22.230000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 38,
+                "size": 1,
+                "total_cores": 38,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.9000000000000001,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 18,
+                "size": 18,
+                "total_cores": 324,
+                "cost_per_instance": 0.79,
+                "instances_cost": 14.22,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 36,
+                "total_cores": 144,
+                "cost_per_instance": 1.48,
+                "instances_cost": 5.92,
+                "available": 3
+            }
+        ],
+        "total_count": 63,
+        "total_cost": 22.43
+    },
+    {
+        "instances": [
+            {
+                "count": 32,
+                "size": 1,
+                "total_cores": 32,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.6,
+                "available": 54
+            },
+            {
+                "count": 18,
+                "size": 18,
+                "total_cores": 324,
+                "cost_per_instance": 0.79,
+                "instances_cost": 14.22,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            }
+        ],
+        "total_count": 54,
+        "total_cost": 22.839999999999996
+    },
+    {
+        "instances": [
+            {
+                "count": 36,
+                "size": 1,
+                "total_cores": 36,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.8,
+                "available": 54
+            },
+            {
+                "count": 7,
+                "size": 2,
+                "total_cores": 14,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.91,
+                "available": 51
+            },
+            {
+                "count": 17,
+                "size": 18,
+                "total_cores": 306,
+                "cost_per_instance": 0.79,
+                "instances_cost": 13.43,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            }
+        ],
+        "total_count": 64,
+        "total_cost": 23.159999999999997
+    },
+    {
+        "instances": [
+            {
+                "count": 36,
+                "size": 1,
+                "total_cores": 36,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.8,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 17,
+                "size": 18,
+                "total_cores": 306,
+                "cost_per_instance": 0.79,
+                "instances_cost": 13.43,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 48,
+                "total_cores": 96,
+                "cost_per_instance": 2.58,
+                "instances_cost": 5.16,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            }
+        ],
+        "total_count": 58,
+        "total_cost": 23.48
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 16,
+                "size": 18,
+                "total_cores": 288,
+                "cost_per_instance": 0.79,
+                "instances_cost": 12.64,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 48,
+                "total_cores": 144,
+                "cost_per_instance": 2.58,
+                "instances_cost": 7.74,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            }
+        ],
+        "total_count": 29,
+        "total_cost": 23.740000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 36,
+                "size": 1,
+                "total_cores": 36,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.8,
+                "available": 54
+            },
+            {
+                "count": 4,
+                "size": 2,
+                "total_cores": 8,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.52,
+                "available": 51
+            },
+            {
+                "count": 16,
+                "size": 18,
+                "total_cores": 288,
+                "cost_per_instance": 0.79,
+                "instances_cost": 12.64,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 48,
+                "total_cores": 144,
+                "cost_per_instance": 2.58,
+                "instances_cost": 7.74,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 24.180000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 34,
+                "size": 1,
+                "total_cores": 34,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.7000000000000002,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 2,
+                "total_cores": 10,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.65,
+                "available": 51
+            },
+            {
+                "count": 16,
+                "size": 18,
+                "total_cores": 288,
+                "cost_per_instance": 0.79,
+                "instances_cost": 12.64,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 48,
+                "total_cores": 144,
+                "cost_per_instance": 2.58,
+                "instances_cost": 7.74,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            }
+        ],
+        "total_count": 59,
+        "total_cost": 24.21
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 15,
+                "size": 18,
+                "total_cores": 270,
+                "cost_per_instance": 0.79,
+                "instances_cost": 11.850000000000001,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 48,
+                "total_cores": 192,
+                "cost_per_instance": 2.58,
+                "instances_cost": 10.32,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            }
+        ],
+        "total_count": 34,
+        "total_cost": 24.35
+    },
+    {
+        "instances": [
+            {
+                "count": 34,
+                "size": 1,
+                "total_cores": 34,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.7000000000000002,
+                "available": 54
+            },
+            {
+                "count": 8,
+                "size": 2,
+                "total_cores": 16,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.04,
+                "available": 51
+            },
+            {
+                "count": 15,
+                "size": 18,
+                "total_cores": 270,
+                "cost_per_instance": 0.79,
+                "instances_cost": 11.850000000000001,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 48,
+                "total_cores": 192,
+                "cost_per_instance": 2.58,
+                "instances_cost": 10.32,
+                "available": 44
+            }
+        ],
+        "total_count": 61,
+        "total_cost": 24.910000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 14,
+                "size": 18,
+                "total_cores": 252,
+                "cost_per_instance": 0.79,
+                "instances_cost": 11.06,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 48,
+                "total_cores": 240,
+                "cost_per_instance": 2.58,
+                "instances_cost": 12.9,
+                "available": 44
+            }
+        ],
+        "total_count": 39,
+        "total_cost": 24.96
+    },
+    {
+        "instances": [
+            {
+                "count": 32,
+                "size": 1,
+                "total_cores": 32,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.6,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 13,
+                "size": 18,
+                "total_cores": 234,
+                "cost_per_instance": 0.79,
+                "instances_cost": 10.27,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 48,
+                "total_cores": 240,
+                "cost_per_instance": 2.58,
+                "instances_cost": 12.9,
+                "available": 44
+            }
+        ],
+        "total_count": 53,
+        "total_cost": 25.16
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 12,
+                "size": 18,
+                "total_cores": 216,
+                "cost_per_instance": 0.79,
+                "instances_cost": 9.48,
+                "available": 3
+            },
+            {
+                "count": 6,
+                "size": 48,
+                "total_cores": 288,
+                "cost_per_instance": 2.58,
+                "instances_cost": 15.48,
+                "available": 44
+            }
+        ],
+        "total_count": 26,
+        "total_cost": 25.36
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 12,
+                "size": 18,
+                "total_cores": 216,
+                "cost_per_instance": 0.79,
+                "instances_cost": 9.48,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 48,
+                "total_cores": 240,
+                "cost_per_instance": 2.58,
+                "instances_cost": 12.9,
+                "available": 44
+            }
+        ],
+        "total_count": 42,
+        "total_cost": 25.43
+    },
+    {
+        "instances": [
+            {
+                "count": 30,
+                "size": 1,
+                "total_cores": 30,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.5,
+                "available": 54
+            },
+            {
+                "count": 6,
+                "size": 2,
+                "total_cores": 12,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.78,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 11,
+                "size": 18,
+                "total_cores": 198,
+                "cost_per_instance": 0.79,
+                "instances_cost": 8.690000000000001,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 48,
+                "total_cores": 240,
+                "cost_per_instance": 2.58,
+                "instances_cost": 12.9,
+                "available": 44
+            }
+        ],
+        "total_count": 53,
+        "total_cost": 25.720000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 32,
+                "total_cores": 96,
+                "cost_per_instance": 1.85,
+                "instances_cost": 5.550000000000001,
+                "available": 39
+            },
+            {
+                "count": 11,
+                "size": 18,
+                "total_cores": 198,
+                "cost_per_instance": 0.79,
+                "instances_cost": 8.690000000000001,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 48,
+                "total_cores": 192,
+                "cost_per_instance": 2.58,
+                "instances_cost": 10.32,
+                "available": 44
+            }
+        ],
+        "total_count": 44,
+        "total_cost": 25.860000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 30,
+                "size": 1,
+                "total_cores": 30,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.5,
+                "available": 54
+            },
+            {
+                "count": 7,
+                "size": 2,
+                "total_cores": 14,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.91,
+                "available": 51
+            },
+            {
+                "count": 3,
+                "size": 32,
+                "total_cores": 96,
+                "cost_per_instance": 1.85,
+                "instances_cost": 5.550000000000001,
+                "available": 39
+            },
+            {
+                "count": 10,
+                "size": 18,
+                "total_cores": 180,
+                "cost_per_instance": 0.79,
+                "instances_cost": 7.9,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 48,
+                "total_cores": 192,
+                "cost_per_instance": 2.58,
+                "instances_cost": 10.32,
+                "available": 44
+            }
+        ],
+        "total_count": 54,
+        "total_cost": 26.18
+    },
+    {
+        "instances": [
+            {
+                "count": 28,
+                "size": 1,
+                "total_cores": 28,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.4000000000000001,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 32,
+                "total_cores": 160,
+                "cost_per_instance": 1.85,
+                "instances_cost": 9.25,
+                "available": 39
+            },
+            {
+                "count": 10,
+                "size": 18,
+                "total_cores": 180,
+                "cost_per_instance": 0.79,
+                "instances_cost": 7.9,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 48,
+                "total_cores": 144,
+                "cost_per_instance": 2.58,
+                "instances_cost": 7.74,
+                "available": 44
+            }
+        ],
+        "total_count": 46,
+        "total_cost": 26.29
+    },
+    {
+        "instances": [
+            {
+                "count": 28,
+                "size": 1,
+                "total_cores": 28,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.4000000000000001,
+                "available": 54
+            },
+            {
+                "count": 9,
+                "size": 2,
+                "total_cores": 18,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.17,
+                "available": 51
+            },
+            {
+                "count": 5,
+                "size": 32,
+                "total_cores": 160,
+                "cost_per_instance": 1.85,
+                "instances_cost": 9.25,
+                "available": 39
+            },
+            {
+                "count": 9,
+                "size": 18,
+                "total_cores": 162,
+                "cost_per_instance": 0.79,
+                "instances_cost": 7.11,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 48,
+                "total_cores": 144,
+                "cost_per_instance": 2.58,
+                "instances_cost": 7.74,
+                "available": 44
+            }
+        ],
+        "total_count": 54,
+        "total_cost": 26.67
+    },
+    {
+        "instances": [
+            {
+                "count": 28,
+                "size": 1,
+                "total_cores": 28,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.4000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 7,
+                "size": 32,
+                "total_cores": 224,
+                "cost_per_instance": 1.85,
+                "instances_cost": 12.950000000000001,
+                "available": 39
+            },
+            {
+                "count": 9,
+                "size": 18,
+                "total_cores": 162,
+                "cost_per_instance": 0.79,
+                "instances_cost": 7.11,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 48,
+                "total_cores": 96,
+                "cost_per_instance": 2.58,
+                "instances_cost": 5.16,
+                "available": 44
+            }
+        ],
+        "total_count": 47,
+        "total_cost": 26.75
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 8,
+                "size": 32,
+                "total_cores": 256,
+                "cost_per_instance": 1.85,
+                "instances_cost": 14.8,
+                "available": 39
+            },
+            {
+                "count": 8,
+                "size": 18,
+                "total_cores": 144,
+                "cost_per_instance": 0.79,
+                "instances_cost": 6.32,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 48,
+                "total_cores": 96,
+                "cost_per_instance": 2.58,
+                "instances_cost": 5.16,
+                "available": 44
+            }
+        ],
+        "total_count": 34,
+        "total_cost": 27.080000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 28,
+                "size": 1,
+                "total_cores": 28,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.4000000000000001,
+                "available": 54
+            },
+            {
+                "count": 2,
+                "size": 2,
+                "total_cores": 4,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.26,
+                "available": 51
+            },
+            {
+                "count": 9,
+                "size": 32,
+                "total_cores": 288,
+                "cost_per_instance": 1.85,
+                "instances_cost": 16.650000000000002,
+                "available": 39
+            },
+            {
+                "count": 8,
+                "size": 18,
+                "total_cores": 144,
+                "cost_per_instance": 0.79,
+                "instances_cost": 6.32,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            }
+        ],
+        "total_count": 48,
+        "total_cost": 27.21
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 9,
+                "size": 32,
+                "total_cores": 288,
+                "cost_per_instance": 1.85,
+                "instances_cost": 16.650000000000002,
+                "available": 39
+            },
+            {
+                "count": 8,
+                "size": 18,
+                "total_cores": 144,
+                "cost_per_instance": 0.79,
+                "instances_cost": 6.32,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            }
+        ],
+        "total_count": 47,
+        "total_cost": 27.240000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 10,
+                "size": 32,
+                "total_cores": 320,
+                "cost_per_instance": 1.85,
+                "instances_cost": 18.5,
+                "available": 39
+            },
+            {
+                "count": 7,
+                "size": 18,
+                "total_cores": 126,
+                "cost_per_instance": 0.79,
+                "instances_cost": 5.53,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            }
+        ],
+        "total_count": 36,
+        "total_cost": 27.509999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 4,
+                "size": 2,
+                "total_cores": 8,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.52,
+                "available": 51
+            },
+            {
+                "count": 11,
+                "size": 32,
+                "total_cores": 352,
+                "cost_per_instance": 1.85,
+                "instances_cost": 20.35,
+                "available": 39
+            },
+            {
+                "count": 7,
+                "size": 18,
+                "total_cores": 126,
+                "cost_per_instance": 0.79,
+                "instances_cost": 5.53,
+                "available": 3
+            }
+        ],
+        "total_count": 48,
+        "total_cost": 27.700000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 8,
+                "size": 2,
+                "total_cores": 16,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.04,
+                "available": 51
+            },
+            {
+                "count": 10,
+                "size": 32,
+                "total_cores": 320,
+                "cost_per_instance": 1.85,
+                "instances_cost": 18.5,
+                "available": 39
+            },
+            {
+                "count": 7,
+                "size": 18,
+                "total_cores": 126,
+                "cost_per_instance": 0.79,
+                "instances_cost": 5.53,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            }
+        ],
+        "total_count": 52,
+        "total_cost": 27.89
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 10,
+                "size": 32,
+                "total_cores": 320,
+                "cost_per_instance": 1.85,
+                "instances_cost": 18.5,
+                "available": 39
+            },
+            {
+                "count": 6,
+                "size": 18,
+                "total_cores": 108,
+                "cost_per_instance": 0.79,
+                "instances_cost": 4.74,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            }
+        ],
+        "total_count": 37,
+        "total_cost": 28.160000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 2,
+                "size": 2,
+                "total_cores": 4,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.26,
+                "available": 51
+            },
+            {
+                "count": 9,
+                "size": 32,
+                "total_cores": 288,
+                "cost_per_instance": 1.85,
+                "instances_cost": 16.650000000000002,
+                "available": 39
+            },
+            {
+                "count": 6,
+                "size": 18,
+                "total_cores": 108,
+                "cost_per_instance": 0.79,
+                "instances_cost": 4.74,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            }
+        ],
+        "total_count": 43,
+        "total_cost": 28.29
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 11,
+                "size": 2,
+                "total_cores": 22,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.4300000000000002,
+                "available": 51
+            },
+            {
+                "count": 9,
+                "size": 32,
+                "total_cores": 288,
+                "cost_per_instance": 1.85,
+                "instances_cost": 16.650000000000002,
+                "available": 39
+            },
+            {
+                "count": 5,
+                "size": 18,
+                "total_cores": 90,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.95,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            }
+        ],
+        "total_count": 51,
+        "total_cost": 28.67
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 7,
+                "size": 2,
+                "total_cores": 14,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.91,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 32,
+                "total_cores": 256,
+                "cost_per_instance": 1.85,
+                "instances_cost": 14.8,
+                "available": 39
+            },
+            {
+                "count": 5,
+                "size": 18,
+                "total_cores": 90,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.95,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 46,
+        "total_cost": 28.7
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 4,
+                "size": 2,
+                "total_cores": 8,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.52,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 32,
+                "total_cores": 256,
+                "cost_per_instance": 1.85,
+                "instances_cost": 14.8,
+                "available": 39
+            },
+            {
+                "count": 4,
+                "size": 18,
+                "total_cores": 72,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.16,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 43,
+        "total_cost": 29.04
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 2,
+                "total_cores": 10,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.65,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 32,
+                "total_cores": 256,
+                "cost_per_instance": 1.85,
+                "instances_cost": 14.8,
+                "available": 39
+            },
+            {
+                "count": 4,
+                "size": 18,
+                "total_cores": 72,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.16,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 42,
+        "total_cost": 29.07
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 7,
+                "size": 32,
+                "total_cores": 224,
+                "cost_per_instance": 1.85,
+                "instances_cost": 12.950000000000001,
+                "available": 39
+            },
+            {
+                "count": 4,
+                "size": 18,
+                "total_cores": 72,
+                "cost_per_instance": 0.79,
+                "instances_cost": 3.16,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 37,
+        "total_cost": 29.1
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 10,
+                "size": 2,
+                "total_cores": 20,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.3,
+                "available": 51
+            },
+            {
+                "count": 7,
+                "size": 32,
+                "total_cores": 224,
+                "cost_per_instance": 1.85,
+                "instances_cost": 12.950000000000001,
+                "available": 39
+            },
+            {
+                "count": 3,
+                "size": 18,
+                "total_cores": 54,
+                "cost_per_instance": 0.79,
+                "instances_cost": 2.37,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 45,
+        "total_cost": 29.480000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 2,
+                "size": 2,
+                "total_cores": 4,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.26,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 32,
+                "total_cores": 192,
+                "cost_per_instance": 1.85,
+                "instances_cost": 11.100000000000001,
+                "available": 39
+            },
+            {
+                "count": 3,
+                "size": 18,
+                "total_cores": 54,
+                "cost_per_instance": 0.79,
+                "instances_cost": 2.37,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.52,
+                "instances_cost": 3.04,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 38,
+        "total_cost": 29.630000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 32,
+                "total_cores": 192,
+                "cost_per_instance": 1.85,
+                "instances_cost": 11.100000000000001,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 64,
+                "total_cores": 256,
+                "cost_per_instance": 3.92,
+                "instances_cost": 15.68,
+                "available": 23
+            }
+        ],
+        "total_count": 37,
+        "total_cost": 29.85
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 4,
+                "size": 2,
+                "total_cores": 8,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.52,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 32,
+                "total_cores": 192,
+                "cost_per_instance": 1.85,
+                "instances_cost": 11.100000000000001,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 64,
+                "total_cores": 256,
+                "cost_per_instance": 3.92,
+                "instances_cost": 15.68,
+                "available": 23
+            }
+        ],
+        "total_count": 36,
+        "total_cost": 29.880000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 8,
+                "size": 2,
+                "total_cores": 16,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.04,
+                "available": 51
+            },
+            {
+                "count": 5,
+                "size": 32,
+                "total_cores": 160,
+                "cost_per_instance": 1.85,
+                "instances_cost": 9.25,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 4,
+                "size": 64,
+                "total_cores": 256,
+                "cost_per_instance": 3.92,
+                "instances_cost": 15.68,
+                "available": 23
+            }
+        ],
+        "total_count": 40,
+        "total_cost": 30.07
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 2,
+                "total_cores": 10,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.65,
+                "available": 51
+            },
+            {
+                "count": 5,
+                "size": 32,
+                "total_cores": 160,
+                "cost_per_instance": 1.85,
+                "instances_cost": 9.25,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.52,
+                "instances_cost": 3.04,
+                "available": 41
+            },
+            {
+                "count": 4,
+                "size": 64,
+                "total_cores": 256,
+                "cost_per_instance": 3.92,
+                "instances_cost": 15.68,
+                "available": 23
+            }
+        ],
+        "total_count": 37,
+        "total_cost": 30.41
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 5,
+                "size": 32,
+                "total_cores": 160,
+                "cost_per_instance": 1.85,
+                "instances_cost": 9.25,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 24,
+                "total_cores": 120,
+                "cost_per_instance": 1.52,
+                "instances_cost": 7.6,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 35,
+        "total_cost": 30.529999999999994
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 2,
+                "total_cores": 10,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.65,
+                "available": 51
+            },
+            {
+                "count": 4,
+                "size": 32,
+                "total_cores": 128,
+                "cost_per_instance": 1.85,
+                "instances_cost": 7.4,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 6,
+                "size": 24,
+                "total_cores": 144,
+                "cost_per_instance": 1.52,
+                "instances_cost": 9.120000000000001,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 39,
+        "total_cost": 30.72
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 2,
+                "size": 2,
+                "total_cores": 4,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.26,
+                "available": 51
+            },
+            {
+                "count": 4,
+                "size": 32,
+                "total_cores": 128,
+                "cost_per_instance": 1.85,
+                "instances_cost": 7.4,
+                "available": 39
+            },
+            {
+                "count": 7,
+                "size": 24,
+                "total_cores": 168,
+                "cost_per_instance": 1.52,
+                "instances_cost": 10.64,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 64,
+                "total_cores": 192,
+                "cost_per_instance": 3.92,
+                "instances_cost": 11.76,
+                "available": 23
+            }
+        ],
+        "total_count": 36,
+        "total_cost": 31.060000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 1,
+                "total_cores": 20,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.0,
+                "available": 54
+            },
+            {
+                "count": 10,
+                "size": 2,
+                "total_cores": 20,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.3,
+                "available": 51
+            },
+            {
+                "count": 4,
+                "size": 32,
+                "total_cores": 128,
+                "cost_per_instance": 1.85,
+                "instances_cost": 7.4,
+                "available": 39
+            },
+            {
+                "count": 9,
+                "size": 24,
+                "total_cores": 216,
+                "cost_per_instance": 1.52,
+                "instances_cost": 13.68,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 45,
+        "total_cost": 31.22
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 11,
+                "size": 2,
+                "total_cores": 22,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.4300000000000002,
+                "available": 51
+            },
+            {
+                "count": 4,
+                "size": 32,
+                "total_cores": 128,
+                "cost_per_instance": 1.85,
+                "instances_cost": 7.4,
+                "available": 39
+            },
+            {
+                "count": 9,
+                "size": 24,
+                "total_cores": 216,
+                "cost_per_instance": 1.52,
+                "instances_cost": 13.68,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 44,
+        "total_cost": 31.25
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 3,
+                "size": 32,
+                "total_cores": 96,
+                "cost_per_instance": 1.85,
+                "instances_cost": 5.550000000000001,
+                "available": 39
+            },
+            {
+                "count": 11,
+                "size": 24,
+                "total_cores": 264,
+                "cost_per_instance": 1.52,
+                "instances_cost": 16.72,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 64,
+                "total_cores": 128,
+                "cost_per_instance": 3.92,
+                "instances_cost": 7.84,
+                "available": 23
+            }
+        ],
+        "total_count": 37,
+        "total_cost": 31.4
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 11,
+                "size": 2,
+                "total_cores": 22,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.4300000000000002,
+                "available": 51
+            },
+            {
+                "count": 3,
+                "size": 32,
+                "total_cores": 96,
+                "cost_per_instance": 1.85,
+                "instances_cost": 5.550000000000001,
+                "available": 39
+            },
+            {
+                "count": 13,
+                "size": 24,
+                "total_cores": 312,
+                "cost_per_instance": 1.52,
+                "instances_cost": 19.76,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            }
+        ],
+        "total_count": 46,
+        "total_cost": 31.560000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 2,
+                "size": 32,
+                "total_cores": 64,
+                "cost_per_instance": 1.85,
+                "instances_cost": 3.7,
+                "available": 39
+            },
+            {
+                "count": 15,
+                "size": 24,
+                "total_cores": 360,
+                "cost_per_instance": 1.52,
+                "instances_cost": 22.8,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            }
+        ],
+        "total_count": 39,
+        "total_cost": 31.71
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 11,
+                "size": 2,
+                "total_cores": 22,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.4300000000000002,
+                "available": 51
+            },
+            {
+                "count": 2,
+                "size": 32,
+                "total_cores": 64,
+                "cost_per_instance": 1.85,
+                "instances_cost": 3.7,
+                "available": 39
+            },
+            {
+                "count": 17,
+                "size": 24,
+                "total_cores": 408,
+                "cost_per_instance": 1.52,
+                "instances_cost": 25.84,
+                "available": 41
+            }
+        ],
+        "total_count": 48,
+        "total_cost": 31.87
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 12,
+                "size": 2,
+                "total_cores": 24,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.56,
+                "available": 51
+            },
+            {
+                "count": 2,
+                "size": 32,
+                "total_cores": 64,
+                "cost_per_instance": 1.85,
+                "instances_cost": 3.7,
+                "available": 39
+            },
+            {
+                "count": 17,
+                "size": 24,
+                "total_cores": 408,
+                "cost_per_instance": 1.52,
+                "instances_cost": 25.84,
+                "available": 41
+            }
+        ],
+        "total_count": 47,
+        "total_cost": 31.9
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 28,
+                "size": 2,
+                "total_cores": 56,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.64,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 17,
+                "size": 24,
+                "total_cores": 408,
+                "cost_per_instance": 1.52,
+                "instances_cost": 25.84,
+                "available": 41
+            }
+        ],
+        "total_count": 62,
+        "total_cost": 32.13
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 32,
+                "size": 2,
+                "total_cores": 64,
+                "cost_per_instance": 0.13,
+                "instances_cost": 4.16,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 16,
+                "size": 24,
+                "total_cores": 384,
+                "cost_per_instance": 1.52,
+                "instances_cost": 24.32,
+                "available": 41
+            }
+        ],
+        "total_count": 66,
+        "total_cost": 32.230000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 32,
+                "size": 2,
+                "total_cores": 64,
+                "cost_per_instance": 0.13,
+                "instances_cost": 4.16,
+                "available": 51
+            },
+            {
+                "count": 3,
+                "size": 16,
+                "total_cores": 48,
+                "cost_per_instance": 1.1,
+                "instances_cost": 3.3000000000000003,
+                "available": 43
+            },
+            {
+                "count": 16,
+                "size": 24,
+                "total_cores": 384,
+                "cost_per_instance": 1.52,
+                "instances_cost": 24.32,
+                "available": 41
+            }
+        ],
+        "total_count": 67,
+        "total_cost": 32.58
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 34,
+                "size": 2,
+                "total_cores": 68,
+                "cost_per_instance": 0.13,
+                "instances_cost": 4.42,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 4,
+                "size": 16,
+                "total_cores": 64,
+                "cost_per_instance": 1.1,
+                "instances_cost": 4.4,
+                "available": 43
+            },
+            {
+                "count": 15,
+                "size": 24,
+                "total_cores": 360,
+                "cost_per_instance": 1.52,
+                "instances_cost": 22.8,
+                "available": 41
+            }
+        ],
+        "total_count": 70,
+        "total_cost": 32.71
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 29,
+                "size": 2,
+                "total_cores": 58,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.77,
+                "available": 51
+            },
+            {
+                "count": 5,
+                "size": 16,
+                "total_cores": 80,
+                "cost_per_instance": 1.1,
+                "instances_cost": 5.5,
+                "available": 43
+            },
+            {
+                "count": 15,
+                "size": 24,
+                "total_cores": 360,
+                "cost_per_instance": 1.52,
+                "instances_cost": 22.8,
+                "available": 41
+            }
+        ],
+        "total_count": 63,
+        "total_cost": 32.769999999999996
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 33,
+                "size": 2,
+                "total_cores": 66,
+                "cost_per_instance": 0.13,
+                "instances_cost": 4.29,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 16,
+                "total_cores": 96,
+                "cost_per_instance": 1.1,
+                "instances_cost": 6.6000000000000005,
+                "available": 43
+            },
+            {
+                "count": 14,
+                "size": 24,
+                "total_cores": 336,
+                "cost_per_instance": 1.52,
+                "instances_cost": 21.28,
+                "available": 41
+            }
+        ],
+        "total_count": 67,
+        "total_cost": 32.870000000000005
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 31,
+                "size": 2,
+                "total_cores": 62,
+                "cost_per_instance": 0.13,
+                "instances_cost": 4.03,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 6,
+                "size": 16,
+                "total_cores": 96,
+                "cost_per_instance": 1.1,
+                "instances_cost": 6.6000000000000005,
+                "available": 43
+            },
+            {
+                "count": 14,
+                "size": 24,
+                "total_cores": 336,
+                "cost_per_instance": 1.52,
+                "instances_cost": 21.28,
+                "available": 41
+            }
+        ],
+        "total_count": 66,
+        "total_cost": 32.900000000000006
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 29,
+                "size": 2,
+                "total_cores": 58,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.77,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 16,
+                "total_cores": 128,
+                "cost_per_instance": 1.1,
+                "instances_cost": 8.8,
+                "available": 43
+            },
+            {
+                "count": 13,
+                "size": 24,
+                "total_cores": 312,
+                "cost_per_instance": 1.52,
+                "instances_cost": 19.76,
+                "available": 41
+            }
+        ],
+        "total_count": 64,
+        "total_cost": 33.03
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 30,
+                "size": 2,
+                "total_cores": 60,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.9000000000000004,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 16,
+                "total_cores": 128,
+                "cost_per_instance": 1.1,
+                "instances_cost": 8.8,
+                "available": 43
+            },
+            {
+                "count": 13,
+                "size": 24,
+                "total_cores": 312,
+                "cost_per_instance": 1.52,
+                "instances_cost": 19.76,
+                "available": 41
+            }
+        ],
+        "total_count": 63,
+        "total_cost": 33.06
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 26,
+                "size": 2,
+                "total_cores": 52,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.38,
+                "available": 51
+            },
+            {
+                "count": 10,
+                "size": 16,
+                "total_cores": 160,
+                "cost_per_instance": 1.1,
+                "instances_cost": 11.0,
+                "available": 43
+            },
+            {
+                "count": 12,
+                "size": 24,
+                "total_cores": 288,
+                "cost_per_instance": 1.52,
+                "instances_cost": 18.240000000000002,
+                "available": 41
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 33.22
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 30,
+                "size": 2,
+                "total_cores": 60,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.9000000000000004,
+                "available": 51
+            },
+            {
+                "count": 11,
+                "size": 16,
+                "total_cores": 176,
+                "cost_per_instance": 1.1,
+                "instances_cost": 12.100000000000001,
+                "available": 43
+            },
+            {
+                "count": 11,
+                "size": 24,
+                "total_cores": 264,
+                "cost_per_instance": 1.52,
+                "instances_cost": 16.72,
+                "available": 41
+            }
+        ],
+        "total_count": 64,
+        "total_cost": 33.32
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 29,
+                "size": 2,
+                "total_cores": 58,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.77,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 11,
+                "size": 16,
+                "total_cores": 176,
+                "cost_per_instance": 1.1,
+                "instances_cost": 12.100000000000001,
+                "available": 43
+            },
+            {
+                "count": 11,
+                "size": 24,
+                "total_cores": 264,
+                "cost_per_instance": 1.52,
+                "instances_cost": 16.72,
+                "available": 41
+            }
+        ],
+        "total_count": 62,
+        "total_cost": 33.379999999999995
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 27,
+                "size": 2,
+                "total_cores": 54,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.5100000000000002,
+                "available": 51
+            },
+            {
+                "count": 13,
+                "size": 16,
+                "total_cores": 208,
+                "cost_per_instance": 1.1,
+                "instances_cost": 14.3,
+                "available": 43
+            },
+            {
+                "count": 10,
+                "size": 24,
+                "total_cores": 240,
+                "cost_per_instance": 1.52,
+                "instances_cost": 15.2,
+                "available": 41
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 33.510000000000005
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 23,
+                "size": 2,
+                "total_cores": 46,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.99,
+                "available": 51
+            },
+            {
+                "count": 15,
+                "size": 16,
+                "total_cores": 240,
+                "cost_per_instance": 1.1,
+                "instances_cost": 16.5,
+                "available": 43
+            },
+            {
+                "count": 9,
+                "size": 24,
+                "total_cores": 216,
+                "cost_per_instance": 1.52,
+                "instances_cost": 13.68,
+                "available": 41
+            }
+        ],
+        "total_count": 57,
+        "total_cost": 33.67
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 24,
+                "size": 2,
+                "total_cores": 48,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.12,
+                "available": 51
+            },
+            {
+                "count": 15,
+                "size": 16,
+                "total_cores": 240,
+                "cost_per_instance": 1.1,
+                "instances_cost": 16.5,
+                "available": 43
+            },
+            {
+                "count": 9,
+                "size": 24,
+                "total_cores": 216,
+                "cost_per_instance": 1.52,
+                "instances_cost": 13.68,
+                "available": 41
+            }
+        ],
+        "total_count": 56,
+        "total_cost": 33.7
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 26,
+                "size": 2,
+                "total_cores": 52,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.38,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 16,
+                "size": 16,
+                "total_cores": 256,
+                "cost_per_instance": 1.1,
+                "instances_cost": 17.6,
+                "available": 43
+            },
+            {
+                "count": 8,
+                "size": 24,
+                "total_cores": 192,
+                "cost_per_instance": 1.52,
+                "instances_cost": 12.16,
+                "available": 41
+            }
+        ],
+        "total_count": 59,
+        "total_cost": 33.83
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 24,
+                "size": 2,
+                "total_cores": 48,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.12,
+                "available": 51
+            },
+            {
+                "count": 18,
+                "size": 16,
+                "total_cores": 288,
+                "cost_per_instance": 1.1,
+                "instances_cost": 19.8,
+                "available": 43
+            },
+            {
+                "count": 7,
+                "size": 24,
+                "total_cores": 168,
+                "cost_per_instance": 1.52,
+                "instances_cost": 10.64,
+                "available": 41
+            }
+        ],
+        "total_count": 57,
+        "total_cost": 33.96
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 25,
+                "size": 2,
+                "total_cores": 50,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.25,
+                "available": 51
+            },
+            {
+                "count": 18,
+                "size": 16,
+                "total_cores": 288,
+                "cost_per_instance": 1.1,
+                "instances_cost": 19.8,
+                "available": 43
+            },
+            {
+                "count": 7,
+                "size": 24,
+                "total_cores": 168,
+                "cost_per_instance": 1.52,
+                "instances_cost": 10.64,
+                "available": 41
+            }
+        ],
+        "total_count": 56,
+        "total_cost": 33.99
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 21,
+                "size": 2,
+                "total_cores": 42,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.73,
+                "available": 51
+            },
+            {
+                "count": 20,
+                "size": 16,
+                "total_cores": 320,
+                "cost_per_instance": 1.1,
+                "instances_cost": 22.0,
+                "available": 43
+            },
+            {
+                "count": 6,
+                "size": 24,
+                "total_cores": 144,
+                "cost_per_instance": 1.52,
+                "instances_cost": 9.120000000000001,
+                "available": 41
+            }
+        ],
+        "total_count": 53,
+        "total_cost": 34.150000000000006
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 23,
+                "size": 2,
+                "total_cores": 46,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.99,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 21,
+                "size": 16,
+                "total_cores": 336,
+                "cost_per_instance": 1.1,
+                "instances_cost": 23.1,
+                "available": 43
+            },
+            {
+                "count": 5,
+                "size": 24,
+                "total_cores": 120,
+                "cost_per_instance": 1.52,
+                "instances_cost": 7.6,
+                "available": 41
+            }
+        ],
+        "total_count": 56,
+        "total_cost": 34.28
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 24,
+                "size": 2,
+                "total_cores": 48,
+                "cost_per_instance": 0.13,
+                "instances_cost": 3.12,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 21,
+                "size": 16,
+                "total_cores": 336,
+                "cost_per_instance": 1.1,
+                "instances_cost": 23.1,
+                "available": 43
+            },
+            {
+                "count": 5,
+                "size": 24,
+                "total_cores": 120,
+                "cost_per_instance": 1.52,
+                "instances_cost": 7.6,
+                "available": 41
+            }
+        ],
+        "total_count": 55,
+        "total_cost": 34.31
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 22,
+                "size": 2,
+                "total_cores": 44,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.8600000000000003,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 21,
+                "size": 16,
+                "total_cores": 336,
+                "cost_per_instance": 1.1,
+                "instances_cost": 23.1,
+                "available": 43
+            },
+            {
+                "count": 5,
+                "size": 24,
+                "total_cores": 120,
+                "cost_per_instance": 1.52,
+                "instances_cost": 7.6,
+                "available": 41
+            }
+        ],
+        "total_count": 53,
+        "total_cost": 34.34
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 22,
+                "size": 2,
+                "total_cores": 44,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.8600000000000003,
+                "available": 51
+            },
+            {
+                "count": 3,
+                "size": 8,
+                "total_cores": 24,
+                "cost_per_instance": 0.58,
+                "instances_cost": 1.7399999999999998,
+                "available": 45
+            },
+            {
+                "count": 20,
+                "size": 16,
+                "total_cores": 320,
+                "cost_per_instance": 1.1,
+                "instances_cost": 22.0,
+                "available": 43
+            },
+            {
+                "count": 5,
+                "size": 24,
+                "total_cores": 120,
+                "cost_per_instance": 1.52,
+                "instances_cost": 7.6,
+                "available": 41
+            }
+        ],
+        "total_count": 54,
+        "total_cost": 34.4
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 22,
+                "size": 2,
+                "total_cores": 44,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.8600000000000003,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 8,
+                "total_cores": 48,
+                "cost_per_instance": 0.58,
+                "instances_cost": 3.4799999999999995,
+                "available": 45
+            },
+            {
+                "count": 20,
+                "size": 16,
+                "total_cores": 320,
+                "cost_per_instance": 1.1,
+                "instances_cost": 22.0,
+                "available": 43
+            },
+            {
+                "count": 4,
+                "size": 24,
+                "total_cores": 96,
+                "cost_per_instance": 1.52,
+                "instances_cost": 6.08,
+                "available": 41
+            }
+        ],
+        "total_count": 56,
+        "total_cost": 34.62
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 22,
+                "size": 2,
+                "total_cores": 44,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.8600000000000003,
+                "available": 51
+            },
+            {
+                "count": 8,
+                "size": 8,
+                "total_cores": 64,
+                "cost_per_instance": 0.58,
+                "instances_cost": 4.64,
+                "available": 45
+            },
+            {
+                "count": 19,
+                "size": 16,
+                "total_cores": 304,
+                "cost_per_instance": 1.1,
+                "instances_cost": 20.900000000000002,
+                "available": 43
+            },
+            {
+                "count": 4,
+                "size": 24,
+                "total_cores": 96,
+                "cost_per_instance": 1.52,
+                "instances_cost": 6.08,
+                "available": 41
+            }
+        ],
+        "total_count": 57,
+        "total_cost": 34.68
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 22,
+                "size": 2,
+                "total_cores": 44,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.8600000000000003,
+                "available": 51
+            },
+            {
+                "count": 11,
+                "size": 8,
+                "total_cores": 88,
+                "cost_per_instance": 0.58,
+                "instances_cost": 6.38,
+                "available": 45
+            },
+            {
+                "count": 19,
+                "size": 16,
+                "total_cores": 304,
+                "cost_per_instance": 1.1,
+                "instances_cost": 20.900000000000002,
+                "available": 43
+            },
+            {
+                "count": 3,
+                "size": 24,
+                "total_cores": 72,
+                "cost_per_instance": 1.52,
+                "instances_cost": 4.5600000000000005,
+                "available": 41
+            }
+        ],
+        "total_count": 59,
+        "total_cost": 34.900000000000006
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 21,
+                "size": 2,
+                "total_cores": 42,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.73,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 11,
+                "size": 8,
+                "total_cores": 88,
+                "cost_per_instance": 0.58,
+                "instances_cost": 6.38,
+                "available": 45
+            },
+            {
+                "count": 19,
+                "size": 16,
+                "total_cores": 304,
+                "cost_per_instance": 1.1,
+                "instances_cost": 20.900000000000002,
+                "available": 43
+            },
+            {
+                "count": 3,
+                "size": 24,
+                "total_cores": 72,
+                "cost_per_instance": 1.52,
+                "instances_cost": 4.5600000000000005,
+                "available": 41
+            }
+        ],
+        "total_count": 57,
+        "total_cost": 34.96
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 21,
+                "size": 2,
+                "total_cores": 42,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.73,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 13,
+                "size": 8,
+                "total_cores": 104,
+                "cost_per_instance": 0.58,
+                "instances_cost": 7.539999999999999,
+                "available": 45
+            },
+            {
+                "count": 18,
+                "size": 16,
+                "total_cores": 288,
+                "cost_per_instance": 1.1,
+                "instances_cost": 19.8,
+                "available": 43
+            },
+            {
+                "count": 3,
+                "size": 24,
+                "total_cores": 72,
+                "cost_per_instance": 1.52,
+                "instances_cost": 4.5600000000000005,
+                "available": 41
+            }
+        ],
+        "total_count": 58,
+        "total_cost": 35.02
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 21,
+                "size": 2,
+                "total_cores": 42,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.73,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 16,
+                "size": 8,
+                "total_cores": 128,
+                "cost_per_instance": 0.58,
+                "instances_cost": 9.28,
+                "available": 45
+            },
+            {
+                "count": 18,
+                "size": 16,
+                "total_cores": 288,
+                "cost_per_instance": 1.1,
+                "instances_cost": 19.8,
+                "available": 43
+            },
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.52,
+                "instances_cost": 3.04,
+                "available": 41
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 35.24
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 19,
+                "size": 2,
+                "total_cores": 38,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.47,
+                "available": 51
+            },
+            {
+                "count": 17,
+                "size": 8,
+                "total_cores": 136,
+                "cost_per_instance": 0.58,
+                "instances_cost": 9.86,
+                "available": 45
+            },
+            {
+                "count": 18,
+                "size": 16,
+                "total_cores": 288,
+                "cost_per_instance": 1.1,
+                "instances_cost": 19.8,
+                "available": 43
+            },
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.52,
+                "instances_cost": 3.04,
+                "available": 41
+            }
+        ],
+        "total_count": 58,
+        "total_cost": 35.27
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 19,
+                "size": 2,
+                "total_cores": 38,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.47,
+                "available": 51
+            },
+            {
+                "count": 19,
+                "size": 8,
+                "total_cores": 152,
+                "cost_per_instance": 0.58,
+                "instances_cost": 11.02,
+                "available": 45
+            },
+            {
+                "count": 17,
+                "size": 16,
+                "total_cores": 272,
+                "cost_per_instance": 1.1,
+                "instances_cost": 18.700000000000003,
+                "available": 43
+            },
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.52,
+                "instances_cost": 3.04,
+                "available": 41
+            }
+        ],
+        "total_count": 59,
+        "total_cost": 35.330000000000005
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 19,
+                "size": 2,
+                "total_cores": 38,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.47,
+                "available": 51
+            },
+            {
+                "count": 22,
+                "size": 8,
+                "total_cores": 176,
+                "cost_per_instance": 0.58,
+                "instances_cost": 12.76,
+                "available": 45
+            },
+            {
+                "count": 17,
+                "size": 16,
+                "total_cores": 272,
+                "cost_per_instance": 1.1,
+                "instances_cost": 18.700000000000003,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            }
+        ],
+        "total_count": 61,
+        "total_cost": 35.550000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 20,
+                "size": 2,
+                "total_cores": 40,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.6,
+                "available": 51
+            },
+            {
+                "count": 22,
+                "size": 8,
+                "total_cores": 176,
+                "cost_per_instance": 0.58,
+                "instances_cost": 12.76,
+                "available": 45
+            },
+            {
+                "count": 17,
+                "size": 16,
+                "total_cores": 272,
+                "cost_per_instance": 1.1,
+                "instances_cost": 18.700000000000003,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 35.580000000000005
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 2,
+                "total_cores": 36,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.34,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 22,
+                "size": 8,
+                "total_cores": 176,
+                "cost_per_instance": 0.58,
+                "instances_cost": 12.76,
+                "available": 45
+            },
+            {
+                "count": 17,
+                "size": 16,
+                "total_cores": 272,
+                "cost_per_instance": 1.1,
+                "instances_cost": 18.700000000000003,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            }
+        ],
+        "total_count": 59,
+        "total_cost": 35.61000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 2,
+                "total_cores": 36,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.34,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 24,
+                "size": 8,
+                "total_cores": 192,
+                "cost_per_instance": 0.58,
+                "instances_cost": 13.919999999999998,
+                "available": 45
+            },
+            {
+                "count": 16,
+                "size": 16,
+                "total_cores": 256,
+                "cost_per_instance": 1.1,
+                "instances_cost": 17.6,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 35.67
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 2,
+                "total_cores": 36,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.34,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 27,
+                "size": 8,
+                "total_cores": 216,
+                "cost_per_instance": 0.58,
+                "instances_cost": 15.659999999999998,
+                "available": 45
+            },
+            {
+                "count": 16,
+                "size": 16,
+                "total_cores": 256,
+                "cost_per_instance": 1.1,
+                "instances_cost": 17.6,
+                "available": 43
+            }
+        ],
+        "total_count": 62,
+        "total_cost": 35.89
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 2,
+                "total_cores": 36,
+                "cost_per_instance": 0.13,
+                "instances_cost": 2.34,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 29,
+                "size": 8,
+                "total_cores": 232,
+                "cost_per_instance": 0.58,
+                "instances_cost": 16.82,
+                "available": 45
+            },
+            {
+                "count": 15,
+                "size": 16,
+                "total_cores": 240,
+                "cost_per_instance": 1.1,
+                "instances_cost": 16.5,
+                "available": 43
+            }
+        ],
+        "total_count": 63,
+        "total_cost": 35.95
+    }
+]

--- a/aws/spot-instances/run2/spot-instance-choices.json
+++ b/aws/spot-instances/run2/spot-instance-choices.json
@@ -62,12 +62,20 @@
     {
         "instances": [
             {
-                "count": 10,
+                "count": 8,
                 "size": 1,
-                "total_cores": 10,
+                "total_cores": 8,
                 "cost_per_instance": 0.05,
-                "instances_cost": 0.5,
+                "instances_cost": 0.4,
                 "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
             },
             {
                 "count": 1,
@@ -84,14 +92,6 @@
                 "cost_per_instance": 1.48,
                 "instances_cost": 1.48,
                 "available": 3
-            },
-            {
-                "count": 2,
-                "size": 96,
-                "total_cores": 192,
-                "cost_per_instance": 3.72,
-                "instances_cost": 7.44,
-                "available": 10
             },
             {
                 "count": 2,
@@ -100,32 +100,72 @@
                 "cost_per_instance": 3.09,
                 "instances_cost": 6.18,
                 "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
             }
         ],
-        "total_count": 16,
-        "total_cost": 16.39
+        "total_count": 14,
+        "total_cost": 14.07
     },
     {
         "instances": [
             {
-                "count": 4,
-                "size": 96,
-                "total_cores": 384,
-                "cost_per_instance": 3.72,
-                "instances_cost": 14.88,
-                "available": 10
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
             },
             {
                 "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
                 "size": 128,
-                "total_cores": 128,
+                "total_cores": 256,
                 "cost_per_instance": 3.09,
-                "instances_cost": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
                 "available": 3
             }
         ],
-        "total_count": 5,
-        "total_cost": 17.97
+        "total_count": 12,
+        "total_cost": 14.129999999999999
     },
     {
         "instances": [
@@ -136,3358 +176,6 @@
                 "cost_per_instance": 0.05,
                 "instances_cost": 0.1,
                 "available": 54
-            },
-            {
-                "count": 1,
-                "size": 18,
-                "total_cores": 18,
-                "cost_per_instance": 0.79,
-                "instances_cost": 0.79,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 36,
-                "total_cores": 108,
-                "cost_per_instance": 1.48,
-                "instances_cost": 4.4399999999999995,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 96,
-                "total_cores": 384,
-                "cost_per_instance": 3.72,
-                "instances_cost": 14.88,
-                "available": 10
-            }
-        ],
-        "total_count": 10,
-        "total_cost": 20.21
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 6,
-                "size": 36,
-                "total_cores": 216,
-                "cost_per_instance": 1.48,
-                "instances_cost": 8.879999999999999,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 96,
-                "total_cores": 288,
-                "cost_per_instance": 3.72,
-                "instances_cost": 11.16,
-                "available": 10
-            }
-        ],
-        "total_count": 17,
-        "total_cost": 20.439999999999998
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 18,
-                "total_cores": 18,
-                "cost_per_instance": 0.79,
-                "instances_cost": 0.79,
-                "available": 3
-            },
-            {
-                "count": 8,
-                "size": 36,
-                "total_cores": 288,
-                "cost_per_instance": 1.48,
-                "instances_cost": 11.84,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 96,
-                "total_cores": 192,
-                "cost_per_instance": 3.72,
-                "instances_cost": 7.44,
-                "available": 10
-            }
-        ],
-        "total_count": 25,
-        "total_cost": 20.77
-    },
-    {
-        "instances": [
-            {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 18,
-                "total_cores": 54,
-                "cost_per_instance": 0.79,
-                "instances_cost": 2.37,
-                "available": 3
-            },
-            {
-                "count": 10,
-                "size": 36,
-                "total_cores": 360,
-                "cost_per_instance": 1.48,
-                "instances_cost": 14.8,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 96,
-                "total_cores": 96,
-                "cost_per_instance": 3.72,
-                "instances_cost": 3.72,
-                "available": 10
-            }
-        ],
-        "total_count": 16,
-        "total_cost": 20.99
-    },
-    {
-        "instances": [
-            {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 18,
-                "total_cores": 90,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.95,
-                "available": 3
-            },
-            {
-                "count": 9,
-                "size": 36,
-                "total_cores": 324,
-                "cost_per_instance": 1.48,
-                "instances_cost": 13.32,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 96,
-                "total_cores": 96,
-                "cost_per_instance": 3.72,
-                "instances_cost": 3.72,
-                "available": 10
-            }
-        ],
-        "total_count": 17,
-        "total_cost": 21.09
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 10,
-                "size": 18,
-                "total_cores": 180,
-                "cost_per_instance": 0.79,
-                "instances_cost": 7.9,
-                "available": 3
-            },
-            {
-                "count": 9,
-                "size": 36,
-                "total_cores": 324,
-                "cost_per_instance": 1.48,
-                "instances_cost": 13.32,
-                "available": 3
-            }
-        ],
-        "total_count": 27,
-        "total_cost": 21.62
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 12,
-                "size": 18,
-                "total_cores": 216,
-                "cost_per_instance": 0.79,
-                "instances_cost": 9.48,
-                "available": 3
-            },
-            {
-                "count": 8,
-                "size": 36,
-                "total_cores": 288,
-                "cost_per_instance": 1.48,
-                "instances_cost": 11.84,
-                "available": 3
-            }
-        ],
-        "total_count": 28,
-        "total_cost": 21.72
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 14,
-                "size": 18,
-                "total_cores": 252,
-                "cost_per_instance": 0.79,
-                "instances_cost": 11.06,
-                "available": 3
-            },
-            {
-                "count": 7,
-                "size": 36,
-                "total_cores": 252,
-                "cost_per_instance": 1.48,
-                "instances_cost": 10.36,
-                "available": 3
-            }
-        ],
-        "total_count": 29,
-        "total_cost": 21.82
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 16,
-                "size": 18,
-                "total_cores": 288,
-                "cost_per_instance": 0.79,
-                "instances_cost": 12.64,
-                "available": 3
-            },
-            {
-                "count": 6,
-                "size": 36,
-                "total_cores": 216,
-                "cost_per_instance": 1.48,
-                "instances_cost": 8.879999999999999,
-                "available": 3
-            }
-        ],
-        "total_count": 30,
-        "total_cost": 21.92
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 18,
-                "size": 18,
-                "total_cores": 324,
-                "cost_per_instance": 0.79,
-                "instances_cost": 14.22,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 36,
-                "total_cores": 180,
-                "cost_per_instance": 1.48,
-                "instances_cost": 7.4,
-                "available": 3
-            }
-        ],
-        "total_count": 31,
-        "total_cost": 22.020000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 26,
-                "size": 1,
-                "total_cores": 26,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.3,
-                "available": 54
-            },
-            {
-                "count": 19,
-                "size": 18,
-                "total_cores": 342,
-                "cost_per_instance": 0.79,
-                "instances_cost": 15.010000000000002,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 36,
-                "total_cores": 144,
-                "cost_per_instance": 1.48,
-                "instances_cost": 5.92,
-                "available": 3
-            }
-        ],
-        "total_count": 49,
-        "total_cost": 22.230000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 38,
-                "size": 1,
-                "total_cores": 38,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.9000000000000001,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 18,
-                "size": 18,
-                "total_cores": 324,
-                "cost_per_instance": 0.79,
-                "instances_cost": 14.22,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 36,
-                "total_cores": 144,
-                "cost_per_instance": 1.48,
-                "instances_cost": 5.92,
-                "available": 3
-            }
-        ],
-        "total_count": 63,
-        "total_cost": 22.43
-    },
-    {
-        "instances": [
-            {
-                "count": 32,
-                "size": 1,
-                "total_cores": 32,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.6,
-                "available": 54
-            },
-            {
-                "count": 18,
-                "size": 18,
-                "total_cores": 324,
-                "cost_per_instance": 0.79,
-                "instances_cost": 14.22,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 48,
-                "total_cores": 48,
-                "cost_per_instance": 2.58,
-                "instances_cost": 2.58,
-                "available": 44
-            },
-            {
-                "count": 3,
-                "size": 36,
-                "total_cores": 108,
-                "cost_per_instance": 1.48,
-                "instances_cost": 4.4399999999999995,
-                "available": 3
-            }
-        ],
-        "total_count": 54,
-        "total_cost": 22.839999999999996
-    },
-    {
-        "instances": [
-            {
-                "count": 36,
-                "size": 1,
-                "total_cores": 36,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.8,
-                "available": 54
-            },
-            {
-                "count": 7,
-                "size": 2,
-                "total_cores": 14,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.91,
-                "available": 51
-            },
-            {
-                "count": 17,
-                "size": 18,
-                "total_cores": 306,
-                "cost_per_instance": 0.79,
-                "instances_cost": 13.43,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 48,
-                "total_cores": 48,
-                "cost_per_instance": 2.58,
-                "instances_cost": 2.58,
-                "available": 44
-            },
-            {
-                "count": 3,
-                "size": 36,
-                "total_cores": 108,
-                "cost_per_instance": 1.48,
-                "instances_cost": 4.4399999999999995,
-                "available": 3
-            }
-        ],
-        "total_count": 64,
-        "total_cost": 23.159999999999997
-    },
-    {
-        "instances": [
-            {
-                "count": 36,
-                "size": 1,
-                "total_cores": 36,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.8,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 2,
-                "total_cores": 2,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.13,
-                "available": 51
-            },
-            {
-                "count": 17,
-                "size": 18,
-                "total_cores": 306,
-                "cost_per_instance": 0.79,
-                "instances_cost": 13.43,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 48,
-                "total_cores": 96,
-                "cost_per_instance": 2.58,
-                "instances_cost": 5.16,
-                "available": 44
-            },
-            {
-                "count": 2,
-                "size": 36,
-                "total_cores": 72,
-                "cost_per_instance": 1.48,
-                "instances_cost": 2.96,
-                "available": 3
-            }
-        ],
-        "total_count": 58,
-        "total_cost": 23.48
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 16,
-                "size": 18,
-                "total_cores": 288,
-                "cost_per_instance": 0.79,
-                "instances_cost": 12.64,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 48,
-                "total_cores": 144,
-                "cost_per_instance": 2.58,
-                "instances_cost": 7.74,
-                "available": 44
-            },
-            {
-                "count": 2,
-                "size": 36,
-                "total_cores": 72,
-                "cost_per_instance": 1.48,
-                "instances_cost": 2.96,
-                "available": 3
-            }
-        ],
-        "total_count": 29,
-        "total_cost": 23.740000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 36,
-                "size": 1,
-                "total_cores": 36,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.8,
-                "available": 54
-            },
-            {
-                "count": 4,
-                "size": 2,
-                "total_cores": 8,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.52,
-                "available": 51
-            },
-            {
-                "count": 16,
-                "size": 18,
-                "total_cores": 288,
-                "cost_per_instance": 0.79,
-                "instances_cost": 12.64,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 48,
-                "total_cores": 144,
-                "cost_per_instance": 2.58,
-                "instances_cost": 7.74,
-                "available": 44
-            },
-            {
-                "count": 1,
-                "size": 36,
-                "total_cores": 36,
-                "cost_per_instance": 1.48,
-                "instances_cost": 1.48,
-                "available": 3
-            }
-        ],
-        "total_count": 60,
-        "total_cost": 24.180000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 34,
-                "size": 1,
-                "total_cores": 34,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.7000000000000002,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 2,
-                "total_cores": 10,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.65,
-                "available": 51
-            },
-            {
-                "count": 16,
-                "size": 18,
-                "total_cores": 288,
-                "cost_per_instance": 0.79,
-                "instances_cost": 12.64,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 48,
-                "total_cores": 144,
-                "cost_per_instance": 2.58,
-                "instances_cost": 7.74,
-                "available": 44
-            },
-            {
-                "count": 1,
-                "size": 36,
-                "total_cores": 36,
-                "cost_per_instance": 1.48,
-                "instances_cost": 1.48,
-                "available": 3
-            }
-        ],
-        "total_count": 59,
-        "total_cost": 24.21
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 15,
-                "size": 18,
-                "total_cores": 270,
-                "cost_per_instance": 0.79,
-                "instances_cost": 11.850000000000001,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 48,
-                "total_cores": 192,
-                "cost_per_instance": 2.58,
-                "instances_cost": 10.32,
-                "available": 44
-            },
-            {
-                "count": 1,
-                "size": 36,
-                "total_cores": 36,
-                "cost_per_instance": 1.48,
-                "instances_cost": 1.48,
-                "available": 3
-            }
-        ],
-        "total_count": 34,
-        "total_cost": 24.35
-    },
-    {
-        "instances": [
-            {
-                "count": 34,
-                "size": 1,
-                "total_cores": 34,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.7000000000000002,
-                "available": 54
-            },
-            {
-                "count": 8,
-                "size": 2,
-                "total_cores": 16,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.04,
-                "available": 51
-            },
-            {
-                "count": 15,
-                "size": 18,
-                "total_cores": 270,
-                "cost_per_instance": 0.79,
-                "instances_cost": 11.850000000000001,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 48,
-                "total_cores": 192,
-                "cost_per_instance": 2.58,
-                "instances_cost": 10.32,
-                "available": 44
-            }
-        ],
-        "total_count": 61,
-        "total_cost": 24.910000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 14,
-                "size": 18,
-                "total_cores": 252,
-                "cost_per_instance": 0.79,
-                "instances_cost": 11.06,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 48,
-                "total_cores": 240,
-                "cost_per_instance": 2.58,
-                "instances_cost": 12.9,
-                "available": 44
-            }
-        ],
-        "total_count": 39,
-        "total_cost": 24.96
-    },
-    {
-        "instances": [
-            {
-                "count": 32,
-                "size": 1,
-                "total_cores": 32,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.6,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 13,
-                "size": 18,
-                "total_cores": 234,
-                "cost_per_instance": 0.79,
-                "instances_cost": 10.27,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 48,
-                "total_cores": 240,
-                "cost_per_instance": 2.58,
-                "instances_cost": 12.9,
-                "available": 44
-            }
-        ],
-        "total_count": 53,
-        "total_cost": 25.16
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 12,
-                "size": 18,
-                "total_cores": 216,
-                "cost_per_instance": 0.79,
-                "instances_cost": 9.48,
-                "available": 3
-            },
-            {
-                "count": 6,
-                "size": 48,
-                "total_cores": 288,
-                "cost_per_instance": 2.58,
-                "instances_cost": 15.48,
-                "available": 44
-            }
-        ],
-        "total_count": 26,
-        "total_cost": 25.36
-    },
-    {
-        "instances": [
-            {
-                "count": 24,
-                "size": 1,
-                "total_cores": 24,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.2000000000000002,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 32,
-                "total_cores": 32,
-                "cost_per_instance": 1.85,
-                "instances_cost": 1.85,
-                "available": 39
-            },
-            {
-                "count": 12,
-                "size": 18,
-                "total_cores": 216,
-                "cost_per_instance": 0.79,
-                "instances_cost": 9.48,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 48,
-                "total_cores": 240,
-                "cost_per_instance": 2.58,
-                "instances_cost": 12.9,
-                "available": 44
-            }
-        ],
-        "total_count": 42,
-        "total_cost": 25.43
-    },
-    {
-        "instances": [
-            {
-                "count": 30,
-                "size": 1,
-                "total_cores": 30,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.5,
-                "available": 54
-            },
-            {
-                "count": 6,
-                "size": 2,
-                "total_cores": 12,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.78,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 32,
-                "total_cores": 32,
-                "cost_per_instance": 1.85,
-                "instances_cost": 1.85,
-                "available": 39
-            },
-            {
-                "count": 11,
-                "size": 18,
-                "total_cores": 198,
-                "cost_per_instance": 0.79,
-                "instances_cost": 8.690000000000001,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 48,
-                "total_cores": 240,
-                "cost_per_instance": 2.58,
-                "instances_cost": 12.9,
-                "available": 44
-            }
-        ],
-        "total_count": 53,
-        "total_cost": 25.720000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 26,
-                "size": 1,
-                "total_cores": 26,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.3,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 32,
-                "total_cores": 96,
-                "cost_per_instance": 1.85,
-                "instances_cost": 5.550000000000001,
-                "available": 39
-            },
-            {
-                "count": 11,
-                "size": 18,
-                "total_cores": 198,
-                "cost_per_instance": 0.79,
-                "instances_cost": 8.690000000000001,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 48,
-                "total_cores": 192,
-                "cost_per_instance": 2.58,
-                "instances_cost": 10.32,
-                "available": 44
-            }
-        ],
-        "total_count": 44,
-        "total_cost": 25.860000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 30,
-                "size": 1,
-                "total_cores": 30,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.5,
-                "available": 54
-            },
-            {
-                "count": 7,
-                "size": 2,
-                "total_cores": 14,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.91,
-                "available": 51
-            },
-            {
-                "count": 3,
-                "size": 32,
-                "total_cores": 96,
-                "cost_per_instance": 1.85,
-                "instances_cost": 5.550000000000001,
-                "available": 39
-            },
-            {
-                "count": 10,
-                "size": 18,
-                "total_cores": 180,
-                "cost_per_instance": 0.79,
-                "instances_cost": 7.9,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 48,
-                "total_cores": 192,
-                "cost_per_instance": 2.58,
-                "instances_cost": 10.32,
-                "available": 44
-            }
-        ],
-        "total_count": 54,
-        "total_cost": 26.18
-    },
-    {
-        "instances": [
-            {
-                "count": 28,
-                "size": 1,
-                "total_cores": 28,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.4000000000000001,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 32,
-                "total_cores": 160,
-                "cost_per_instance": 1.85,
-                "instances_cost": 9.25,
-                "available": 39
-            },
-            {
-                "count": 10,
-                "size": 18,
-                "total_cores": 180,
-                "cost_per_instance": 0.79,
-                "instances_cost": 7.9,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 48,
-                "total_cores": 144,
-                "cost_per_instance": 2.58,
-                "instances_cost": 7.74,
-                "available": 44
-            }
-        ],
-        "total_count": 46,
-        "total_cost": 26.29
-    },
-    {
-        "instances": [
-            {
-                "count": 28,
-                "size": 1,
-                "total_cores": 28,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.4000000000000001,
-                "available": 54
-            },
-            {
-                "count": 9,
-                "size": 2,
-                "total_cores": 18,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.17,
-                "available": 51
-            },
-            {
-                "count": 5,
-                "size": 32,
-                "total_cores": 160,
-                "cost_per_instance": 1.85,
-                "instances_cost": 9.25,
-                "available": 39
-            },
-            {
-                "count": 9,
-                "size": 18,
-                "total_cores": 162,
-                "cost_per_instance": 0.79,
-                "instances_cost": 7.11,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 48,
-                "total_cores": 144,
-                "cost_per_instance": 2.58,
-                "instances_cost": 7.74,
-                "available": 44
-            }
-        ],
-        "total_count": 54,
-        "total_cost": 26.67
-    },
-    {
-        "instances": [
-            {
-                "count": 28,
-                "size": 1,
-                "total_cores": 28,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.4000000000000001,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 2,
-                "total_cores": 2,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.13,
-                "available": 51
-            },
-            {
-                "count": 7,
-                "size": 32,
-                "total_cores": 224,
-                "cost_per_instance": 1.85,
-                "instances_cost": 12.950000000000001,
-                "available": 39
-            },
-            {
-                "count": 9,
-                "size": 18,
-                "total_cores": 162,
-                "cost_per_instance": 0.79,
-                "instances_cost": 7.11,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 48,
-                "total_cores": 96,
-                "cost_per_instance": 2.58,
-                "instances_cost": 5.16,
-                "available": 44
-            }
-        ],
-        "total_count": 47,
-        "total_cost": 26.75
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 8,
-                "size": 32,
-                "total_cores": 256,
-                "cost_per_instance": 1.85,
-                "instances_cost": 14.8,
-                "available": 39
-            },
-            {
-                "count": 8,
-                "size": 18,
-                "total_cores": 144,
-                "cost_per_instance": 0.79,
-                "instances_cost": 6.32,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 48,
-                "total_cores": 96,
-                "cost_per_instance": 2.58,
-                "instances_cost": 5.16,
-                "available": 44
-            }
-        ],
-        "total_count": 34,
-        "total_cost": 27.080000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 28,
-                "size": 1,
-                "total_cores": 28,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.4000000000000001,
-                "available": 54
-            },
-            {
-                "count": 2,
-                "size": 2,
-                "total_cores": 4,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.26,
-                "available": 51
-            },
-            {
-                "count": 9,
-                "size": 32,
-                "total_cores": 288,
-                "cost_per_instance": 1.85,
-                "instances_cost": 16.650000000000002,
-                "available": 39
-            },
-            {
-                "count": 8,
-                "size": 18,
-                "total_cores": 144,
-                "cost_per_instance": 0.79,
-                "instances_cost": 6.32,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 48,
-                "total_cores": 48,
-                "cost_per_instance": 2.58,
-                "instances_cost": 2.58,
-                "available": 44
-            }
-        ],
-        "total_count": 48,
-        "total_cost": 27.21
-    },
-    {
-        "instances": [
-            {
-                "count": 26,
-                "size": 1,
-                "total_cores": 26,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.3,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 9,
-                "size": 32,
-                "total_cores": 288,
-                "cost_per_instance": 1.85,
-                "instances_cost": 16.650000000000002,
-                "available": 39
-            },
-            {
-                "count": 8,
-                "size": 18,
-                "total_cores": 144,
-                "cost_per_instance": 0.79,
-                "instances_cost": 6.32,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 48,
-                "total_cores": 48,
-                "cost_per_instance": 2.58,
-                "instances_cost": 2.58,
-                "available": 44
-            }
-        ],
-        "total_count": 47,
-        "total_cost": 27.240000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 10,
-                "size": 32,
-                "total_cores": 320,
-                "cost_per_instance": 1.85,
-                "instances_cost": 18.5,
-                "available": 39
-            },
-            {
-                "count": 7,
-                "size": 18,
-                "total_cores": 126,
-                "cost_per_instance": 0.79,
-                "instances_cost": 5.53,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 48,
-                "total_cores": 48,
-                "cost_per_instance": 2.58,
-                "instances_cost": 2.58,
-                "available": 44
-            }
-        ],
-        "total_count": 36,
-        "total_cost": 27.509999999999998
-    },
-    {
-        "instances": [
-            {
-                "count": 26,
-                "size": 1,
-                "total_cores": 26,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.3,
-                "available": 54
-            },
-            {
-                "count": 4,
-                "size": 2,
-                "total_cores": 8,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.52,
-                "available": 51
-            },
-            {
-                "count": 11,
-                "size": 32,
-                "total_cores": 352,
-                "cost_per_instance": 1.85,
-                "instances_cost": 20.35,
-                "available": 39
-            },
-            {
-                "count": 7,
-                "size": 18,
-                "total_cores": 126,
-                "cost_per_instance": 0.79,
-                "instances_cost": 5.53,
-                "available": 3
-            }
-        ],
-        "total_count": 48,
-        "total_cost": 27.700000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 26,
-                "size": 1,
-                "total_cores": 26,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.3,
-                "available": 54
-            },
-            {
-                "count": 8,
-                "size": 2,
-                "total_cores": 16,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.04,
-                "available": 51
-            },
-            {
-                "count": 10,
-                "size": 32,
-                "total_cores": 320,
-                "cost_per_instance": 1.85,
-                "instances_cost": 18.5,
-                "available": 39
-            },
-            {
-                "count": 7,
-                "size": 18,
-                "total_cores": 126,
-                "cost_per_instance": 0.79,
-                "instances_cost": 5.53,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            }
-        ],
-        "total_count": 52,
-        "total_cost": 27.89
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 10,
-                "size": 32,
-                "total_cores": 320,
-                "cost_per_instance": 1.85,
-                "instances_cost": 18.5,
-                "available": 39
-            },
-            {
-                "count": 6,
-                "size": 18,
-                "total_cores": 108,
-                "cost_per_instance": 0.79,
-                "instances_cost": 4.74,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 64,
-                "total_cores": 64,
-                "cost_per_instance": 3.92,
-                "instances_cost": 3.92,
-                "available": 23
-            }
-        ],
-        "total_count": 37,
-        "total_cost": 28.160000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 24,
-                "size": 1,
-                "total_cores": 24,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.2000000000000002,
-                "available": 54
-            },
-            {
-                "count": 2,
-                "size": 2,
-                "total_cores": 4,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.26,
-                "available": 51
-            },
-            {
-                "count": 9,
-                "size": 32,
-                "total_cores": 288,
-                "cost_per_instance": 1.85,
-                "instances_cost": 16.650000000000002,
-                "available": 39
-            },
-            {
-                "count": 6,
-                "size": 18,
-                "total_cores": 108,
-                "cost_per_instance": 0.79,
-                "instances_cost": 4.74,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            },
-            {
-                "count": 1,
-                "size": 64,
-                "total_cores": 64,
-                "cost_per_instance": 3.92,
-                "instances_cost": 3.92,
-                "available": 23
-            }
-        ],
-        "total_count": 43,
-        "total_cost": 28.29
-    },
-    {
-        "instances": [
-            {
-                "count": 24,
-                "size": 1,
-                "total_cores": 24,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.2000000000000002,
-                "available": 54
-            },
-            {
-                "count": 11,
-                "size": 2,
-                "total_cores": 22,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.4300000000000002,
-                "available": 51
-            },
-            {
-                "count": 9,
-                "size": 32,
-                "total_cores": 288,
-                "cost_per_instance": 1.85,
-                "instances_cost": 16.650000000000002,
-                "available": 39
-            },
-            {
-                "count": 5,
-                "size": 18,
-                "total_cores": 90,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.95,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            },
-            {
-                "count": 1,
-                "size": 64,
-                "total_cores": 64,
-                "cost_per_instance": 3.92,
-                "instances_cost": 3.92,
-                "available": 23
-            }
-        ],
-        "total_count": 51,
-        "total_cost": 28.67
-    },
-    {
-        "instances": [
-            {
-                "count": 24,
-                "size": 1,
-                "total_cores": 24,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.2000000000000002,
-                "available": 54
-            },
-            {
-                "count": 7,
-                "size": 2,
-                "total_cores": 14,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.91,
-                "available": 51
-            },
-            {
-                "count": 8,
-                "size": 32,
-                "total_cores": 256,
-                "cost_per_instance": 1.85,
-                "instances_cost": 14.8,
-                "available": 39
-            },
-            {
-                "count": 5,
-                "size": 18,
-                "total_cores": 90,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.95,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 46,
-        "total_cost": 28.7
-    },
-    {
-        "instances": [
-            {
-                "count": 24,
-                "size": 1,
-                "total_cores": 24,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.2000000000000002,
-                "available": 54
-            },
-            {
-                "count": 4,
-                "size": 2,
-                "total_cores": 8,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.52,
-                "available": 51
-            },
-            {
-                "count": 8,
-                "size": 32,
-                "total_cores": 256,
-                "cost_per_instance": 1.85,
-                "instances_cost": 14.8,
-                "available": 39
-            },
-            {
-                "count": 4,
-                "size": 18,
-                "total_cores": 72,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.16,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 43,
-        "total_cost": 29.04
-    },
-    {
-        "instances": [
-            {
-                "count": 22,
-                "size": 1,
-                "total_cores": 22,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.1,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 2,
-                "total_cores": 10,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.65,
-                "available": 51
-            },
-            {
-                "count": 8,
-                "size": 32,
-                "total_cores": 256,
-                "cost_per_instance": 1.85,
-                "instances_cost": 14.8,
-                "available": 39
-            },
-            {
-                "count": 4,
-                "size": 18,
-                "total_cores": 72,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.16,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 42,
-        "total_cost": 29.07
-    },
-    {
-        "instances": [
-            {
-                "count": 22,
-                "size": 1,
-                "total_cores": 22,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.1,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 2,
-                "total_cores": 2,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.13,
-                "available": 51
-            },
-            {
-                "count": 7,
-                "size": 32,
-                "total_cores": 224,
-                "cost_per_instance": 1.85,
-                "instances_cost": 12.950000000000001,
-                "available": 39
-            },
-            {
-                "count": 4,
-                "size": 18,
-                "total_cores": 72,
-                "cost_per_instance": 0.79,
-                "instances_cost": 3.16,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 37,
-        "total_cost": 29.1
-    },
-    {
-        "instances": [
-            {
-                "count": 22,
-                "size": 1,
-                "total_cores": 22,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.1,
-                "available": 54
-            },
-            {
-                "count": 10,
-                "size": 2,
-                "total_cores": 20,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.3,
-                "available": 51
-            },
-            {
-                "count": 7,
-                "size": 32,
-                "total_cores": 224,
-                "cost_per_instance": 1.85,
-                "instances_cost": 12.950000000000001,
-                "available": 39
-            },
-            {
-                "count": 3,
-                "size": 18,
-                "total_cores": 54,
-                "cost_per_instance": 0.79,
-                "instances_cost": 2.37,
-                "available": 3
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 45,
-        "total_cost": 29.480000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 22,
-                "size": 1,
-                "total_cores": 22,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.1,
-                "available": 54
-            },
-            {
-                "count": 2,
-                "size": 2,
-                "total_cores": 4,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.26,
-                "available": 51
-            },
-            {
-                "count": 6,
-                "size": 32,
-                "total_cores": 192,
-                "cost_per_instance": 1.85,
-                "instances_cost": 11.100000000000001,
-                "available": 39
-            },
-            {
-                "count": 3,
-                "size": 18,
-                "total_cores": 54,
-                "cost_per_instance": 0.79,
-                "instances_cost": 2.37,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 24,
-                "total_cores": 48,
-                "cost_per_instance": 1.52,
-                "instances_cost": 3.04,
-                "available": 41
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 38,
-        "total_cost": 29.630000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 22,
-                "size": 1,
-                "total_cores": 22,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.1,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 6,
-                "size": 32,
-                "total_cores": 192,
-                "cost_per_instance": 1.85,
-                "instances_cost": 11.100000000000001,
-                "available": 39
-            },
-            {
-                "count": 2,
-                "size": 18,
-                "total_cores": 36,
-                "cost_per_instance": 0.79,
-                "instances_cost": 1.58,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 64,
-                "total_cores": 256,
-                "cost_per_instance": 3.92,
-                "instances_cost": 15.68,
-                "available": 23
-            }
-        ],
-        "total_count": 37,
-        "total_cost": 29.85
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 4,
-                "size": 2,
-                "total_cores": 8,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.52,
-                "available": 51
-            },
-            {
-                "count": 6,
-                "size": 32,
-                "total_cores": 192,
-                "cost_per_instance": 1.85,
-                "instances_cost": 11.100000000000001,
-                "available": 39
-            },
-            {
-                "count": 2,
-                "size": 18,
-                "total_cores": 36,
-                "cost_per_instance": 0.79,
-                "instances_cost": 1.58,
-                "available": 3
-            },
-            {
-                "count": 4,
-                "size": 64,
-                "total_cores": 256,
-                "cost_per_instance": 3.92,
-                "instances_cost": 15.68,
-                "available": 23
-            }
-        ],
-        "total_count": 36,
-        "total_cost": 29.880000000000003
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 8,
-                "size": 2,
-                "total_cores": 16,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.04,
-                "available": 51
-            },
-            {
-                "count": 5,
-                "size": 32,
-                "total_cores": 160,
-                "cost_per_instance": 1.85,
-                "instances_cost": 9.25,
-                "available": 39
-            },
-            {
-                "count": 2,
-                "size": 18,
-                "total_cores": 36,
-                "cost_per_instance": 0.79,
-                "instances_cost": 1.58,
-                "available": 3
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            },
-            {
-                "count": 4,
-                "size": 64,
-                "total_cores": 256,
-                "cost_per_instance": 3.92,
-                "instances_cost": 15.68,
-                "available": 23
-            }
-        ],
-        "total_count": 40,
-        "total_cost": 30.07
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 2,
-                "total_cores": 10,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.65,
-                "available": 51
-            },
-            {
-                "count": 5,
-                "size": 32,
-                "total_cores": 160,
-                "cost_per_instance": 1.85,
-                "instances_cost": 9.25,
-                "available": 39
-            },
-            {
-                "count": 1,
-                "size": 18,
-                "total_cores": 18,
-                "cost_per_instance": 0.79,
-                "instances_cost": 0.79,
-                "available": 3
-            },
-            {
-                "count": 2,
-                "size": 24,
-                "total_cores": 48,
-                "cost_per_instance": 1.52,
-                "instances_cost": 3.04,
-                "available": 41
-            },
-            {
-                "count": 4,
-                "size": 64,
-                "total_cores": 256,
-                "cost_per_instance": 3.92,
-                "instances_cost": 15.68,
-                "available": 23
-            }
-        ],
-        "total_count": 37,
-        "total_cost": 30.41
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 1,
-                "size": 2,
-                "total_cores": 2,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.13,
-                "available": 51
-            },
-            {
-                "count": 5,
-                "size": 32,
-                "total_cores": 160,
-                "cost_per_instance": 1.85,
-                "instances_cost": 9.25,
-                "available": 39
-            },
-            {
-                "count": 1,
-                "size": 18,
-                "total_cores": 18,
-                "cost_per_instance": 0.79,
-                "instances_cost": 0.79,
-                "available": 3
-            },
-            {
-                "count": 5,
-                "size": 24,
-                "total_cores": 120,
-                "cost_per_instance": 1.52,
-                "instances_cost": 7.6,
-                "available": 41
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 35,
-        "total_cost": 30.529999999999994
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 5,
-                "size": 2,
-                "total_cores": 10,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.65,
-                "available": 51
-            },
-            {
-                "count": 4,
-                "size": 32,
-                "total_cores": 128,
-                "cost_per_instance": 1.85,
-                "instances_cost": 7.4,
-                "available": 39
-            },
-            {
-                "count": 1,
-                "size": 18,
-                "total_cores": 18,
-                "cost_per_instance": 0.79,
-                "instances_cost": 0.79,
-                "available": 3
-            },
-            {
-                "count": 6,
-                "size": 24,
-                "total_cores": 144,
-                "cost_per_instance": 1.52,
-                "instances_cost": 9.120000000000001,
-                "available": 41
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 39,
-        "total_cost": 30.72
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 2,
-                "size": 2,
-                "total_cores": 4,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.26,
-                "available": 51
-            },
-            {
-                "count": 4,
-                "size": 32,
-                "total_cores": 128,
-                "cost_per_instance": 1.85,
-                "instances_cost": 7.4,
-                "available": 39
-            },
-            {
-                "count": 7,
-                "size": 24,
-                "total_cores": 168,
-                "cost_per_instance": 1.52,
-                "instances_cost": 10.64,
-                "available": 41
-            },
-            {
-                "count": 3,
-                "size": 64,
-                "total_cores": 192,
-                "cost_per_instance": 3.92,
-                "instances_cost": 11.76,
-                "available": 23
-            }
-        ],
-        "total_count": 36,
-        "total_cost": 31.060000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 1,
-                "total_cores": 20,
-                "cost_per_instance": 0.05,
-                "instances_cost": 1.0,
-                "available": 54
-            },
-            {
-                "count": 10,
-                "size": 2,
-                "total_cores": 20,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.3,
-                "available": 51
-            },
-            {
-                "count": 4,
-                "size": 32,
-                "total_cores": 128,
-                "cost_per_instance": 1.85,
-                "instances_cost": 7.4,
-                "available": 39
-            },
-            {
-                "count": 9,
-                "size": 24,
-                "total_cores": 216,
-                "cost_per_instance": 1.52,
-                "instances_cost": 13.68,
-                "available": 41
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 45,
-        "total_cost": 31.22
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 11,
-                "size": 2,
-                "total_cores": 22,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.4300000000000002,
-                "available": 51
-            },
-            {
-                "count": 4,
-                "size": 32,
-                "total_cores": 128,
-                "cost_per_instance": 1.85,
-                "instances_cost": 7.4,
-                "available": 39
-            },
-            {
-                "count": 9,
-                "size": 24,
-                "total_cores": 216,
-                "cost_per_instance": 1.52,
-                "instances_cost": 13.68,
-                "available": 41
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 44,
-        "total_cost": 31.25
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 3,
-                "size": 32,
-                "total_cores": 96,
-                "cost_per_instance": 1.85,
-                "instances_cost": 5.550000000000001,
-                "available": 39
-            },
-            {
-                "count": 11,
-                "size": 24,
-                "total_cores": 264,
-                "cost_per_instance": 1.52,
-                "instances_cost": 16.72,
-                "available": 41
-            },
-            {
-                "count": 2,
-                "size": 64,
-                "total_cores": 128,
-                "cost_per_instance": 3.92,
-                "instances_cost": 7.84,
-                "available": 23
-            }
-        ],
-        "total_count": 37,
-        "total_cost": 31.4
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 11,
-                "size": 2,
-                "total_cores": 22,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.4300000000000002,
-                "available": 51
-            },
-            {
-                "count": 3,
-                "size": 32,
-                "total_cores": 96,
-                "cost_per_instance": 1.85,
-                "instances_cost": 5.550000000000001,
-                "available": 39
-            },
-            {
-                "count": 13,
-                "size": 24,
-                "total_cores": 312,
-                "cost_per_instance": 1.52,
-                "instances_cost": 19.76,
-                "available": 41
-            },
-            {
-                "count": 1,
-                "size": 64,
-                "total_cores": 64,
-                "cost_per_instance": 3.92,
-                "instances_cost": 3.92,
-                "available": 23
-            }
-        ],
-        "total_count": 46,
-        "total_cost": 31.560000000000002
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 3,
-                "size": 2,
-                "total_cores": 6,
-                "cost_per_instance": 0.13,
-                "instances_cost": 0.39,
-                "available": 51
-            },
-            {
-                "count": 2,
-                "size": 32,
-                "total_cores": 64,
-                "cost_per_instance": 1.85,
-                "instances_cost": 3.7,
-                "available": 39
-            },
-            {
-                "count": 15,
-                "size": 24,
-                "total_cores": 360,
-                "cost_per_instance": 1.52,
-                "instances_cost": 22.8,
-                "available": 41
-            },
-            {
-                "count": 1,
-                "size": 64,
-                "total_cores": 64,
-                "cost_per_instance": 3.92,
-                "instances_cost": 3.92,
-                "available": 23
-            }
-        ],
-        "total_count": 39,
-        "total_cost": 31.71
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 1,
-                "total_cores": 18,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.9,
-                "available": 54
-            },
-            {
-                "count": 11,
-                "size": 2,
-                "total_cores": 22,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.4300000000000002,
-                "available": 51
-            },
-            {
-                "count": 2,
-                "size": 32,
-                "total_cores": 64,
-                "cost_per_instance": 1.85,
-                "instances_cost": 3.7,
-                "available": 39
-            },
-            {
-                "count": 17,
-                "size": 24,
-                "total_cores": 408,
-                "cost_per_instance": 1.52,
-                "instances_cost": 25.84,
-                "available": 41
-            }
-        ],
-        "total_count": 48,
-        "total_cost": 31.87
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 12,
-                "size": 2,
-                "total_cores": 24,
-                "cost_per_instance": 0.13,
-                "instances_cost": 1.56,
-                "available": 51
-            },
-            {
-                "count": 2,
-                "size": 32,
-                "total_cores": 64,
-                "cost_per_instance": 1.85,
-                "instances_cost": 3.7,
-                "available": 39
-            },
-            {
-                "count": 17,
-                "size": 24,
-                "total_cores": 408,
-                "cost_per_instance": 1.52,
-                "instances_cost": 25.84,
-                "available": 41
-            }
-        ],
-        "total_count": 47,
-        "total_cost": 31.9
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 28,
-                "size": 2,
-                "total_cores": 56,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.64,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 32,
-                "total_cores": 32,
-                "cost_per_instance": 1.85,
-                "instances_cost": 1.85,
-                "available": 39
-            },
-            {
-                "count": 17,
-                "size": 24,
-                "total_cores": 408,
-                "cost_per_instance": 1.52,
-                "instances_cost": 25.84,
-                "available": 41
-            }
-        ],
-        "total_count": 62,
-        "total_cost": 32.13
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 32,
-                "size": 2,
-                "total_cores": 64,
-                "cost_per_instance": 0.13,
-                "instances_cost": 4.16,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 16,
-                "total_cores": 16,
-                "cost_per_instance": 1.1,
-                "instances_cost": 1.1,
-                "available": 43
-            },
-            {
-                "count": 1,
-                "size": 32,
-                "total_cores": 32,
-                "cost_per_instance": 1.85,
-                "instances_cost": 1.85,
-                "available": 39
-            },
-            {
-                "count": 16,
-                "size": 24,
-                "total_cores": 384,
-                "cost_per_instance": 1.52,
-                "instances_cost": 24.32,
-                "available": 41
-            }
-        ],
-        "total_count": 66,
-        "total_cost": 32.230000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 32,
-                "size": 2,
-                "total_cores": 64,
-                "cost_per_instance": 0.13,
-                "instances_cost": 4.16,
-                "available": 51
-            },
-            {
-                "count": 3,
-                "size": 16,
-                "total_cores": 48,
-                "cost_per_instance": 1.1,
-                "instances_cost": 3.3000000000000003,
-                "available": 43
-            },
-            {
-                "count": 16,
-                "size": 24,
-                "total_cores": 384,
-                "cost_per_instance": 1.52,
-                "instances_cost": 24.32,
-                "available": 41
-            }
-        ],
-        "total_count": 67,
-        "total_cost": 32.58
-    },
-    {
-        "instances": [
-            {
-                "count": 16,
-                "size": 1,
-                "total_cores": 16,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.8,
-                "available": 54
-            },
-            {
-                "count": 34,
-                "size": 2,
-                "total_cores": 68,
-                "cost_per_instance": 0.13,
-                "instances_cost": 4.42,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 4,
-                "size": 16,
-                "total_cores": 64,
-                "cost_per_instance": 1.1,
-                "instances_cost": 4.4,
-                "available": 43
-            },
-            {
-                "count": 15,
-                "size": 24,
-                "total_cores": 360,
-                "cost_per_instance": 1.52,
-                "instances_cost": 22.8,
-                "available": 41
-            }
-        ],
-        "total_count": 70,
-        "total_cost": 32.71
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 29,
-                "size": 2,
-                "total_cores": 58,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.77,
-                "available": 51
-            },
-            {
-                "count": 5,
-                "size": 16,
-                "total_cores": 80,
-                "cost_per_instance": 1.1,
-                "instances_cost": 5.5,
-                "available": 43
-            },
-            {
-                "count": 15,
-                "size": 24,
-                "total_cores": 360,
-                "cost_per_instance": 1.52,
-                "instances_cost": 22.8,
-                "available": 41
-            }
-        ],
-        "total_count": 63,
-        "total_cost": 32.769999999999996
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 33,
-                "size": 2,
-                "total_cores": 66,
-                "cost_per_instance": 0.13,
-                "instances_cost": 4.29,
-                "available": 51
-            },
-            {
-                "count": 6,
-                "size": 16,
-                "total_cores": 96,
-                "cost_per_instance": 1.1,
-                "instances_cost": 6.6000000000000005,
-                "available": 43
-            },
-            {
-                "count": 14,
-                "size": 24,
-                "total_cores": 336,
-                "cost_per_instance": 1.52,
-                "instances_cost": 21.28,
-                "available": 41
-            }
-        ],
-        "total_count": 67,
-        "total_cost": 32.870000000000005
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 31,
-                "size": 2,
-                "total_cores": 62,
-                "cost_per_instance": 0.13,
-                "instances_cost": 4.03,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 6,
-                "size": 16,
-                "total_cores": 96,
-                "cost_per_instance": 1.1,
-                "instances_cost": 6.6000000000000005,
-                "available": 43
-            },
-            {
-                "count": 14,
-                "size": 24,
-                "total_cores": 336,
-                "cost_per_instance": 1.52,
-                "instances_cost": 21.28,
-                "available": 41
-            }
-        ],
-        "total_count": 66,
-        "total_cost": 32.900000000000006
-    },
-    {
-        "instances": [
-            {
-                "count": 14,
-                "size": 1,
-                "total_cores": 14,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.7000000000000001,
-                "available": 54
-            },
-            {
-                "count": 29,
-                "size": 2,
-                "total_cores": 58,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.77,
-                "available": 51
-            },
-            {
-                "count": 8,
-                "size": 16,
-                "total_cores": 128,
-                "cost_per_instance": 1.1,
-                "instances_cost": 8.8,
-                "available": 43
-            },
-            {
-                "count": 13,
-                "size": 24,
-                "total_cores": 312,
-                "cost_per_instance": 1.52,
-                "instances_cost": 19.76,
-                "available": 41
-            }
-        ],
-        "total_count": 64,
-        "total_cost": 33.03
-    },
-    {
-        "instances": [
-            {
-                "count": 12,
-                "size": 1,
-                "total_cores": 12,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.6000000000000001,
-                "available": 54
-            },
-            {
-                "count": 30,
-                "size": 2,
-                "total_cores": 60,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.9000000000000004,
-                "available": 51
-            },
-            {
-                "count": 8,
-                "size": 16,
-                "total_cores": 128,
-                "cost_per_instance": 1.1,
-                "instances_cost": 8.8,
-                "available": 43
-            },
-            {
-                "count": 13,
-                "size": 24,
-                "total_cores": 312,
-                "cost_per_instance": 1.52,
-                "instances_cost": 19.76,
-                "available": 41
-            }
-        ],
-        "total_count": 63,
-        "total_cost": 33.06
-    },
-    {
-        "instances": [
-            {
-                "count": 12,
-                "size": 1,
-                "total_cores": 12,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.6000000000000001,
-                "available": 54
-            },
-            {
-                "count": 26,
-                "size": 2,
-                "total_cores": 52,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.38,
-                "available": 51
-            },
-            {
-                "count": 10,
-                "size": 16,
-                "total_cores": 160,
-                "cost_per_instance": 1.1,
-                "instances_cost": 11.0,
-                "available": 43
-            },
-            {
-                "count": 12,
-                "size": 24,
-                "total_cores": 288,
-                "cost_per_instance": 1.52,
-                "instances_cost": 18.240000000000002,
-                "available": 41
-            }
-        ],
-        "total_count": 60,
-        "total_cost": 33.22
-    },
-    {
-        "instances": [
-            {
-                "count": 12,
-                "size": 1,
-                "total_cores": 12,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.6000000000000001,
-                "available": 54
-            },
-            {
-                "count": 30,
-                "size": 2,
-                "total_cores": 60,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.9000000000000004,
-                "available": 51
-            },
-            {
-                "count": 11,
-                "size": 16,
-                "total_cores": 176,
-                "cost_per_instance": 1.1,
-                "instances_cost": 12.100000000000001,
-                "available": 43
-            },
-            {
-                "count": 11,
-                "size": 24,
-                "total_cores": 264,
-                "cost_per_instance": 1.52,
-                "instances_cost": 16.72,
-                "available": 41
-            }
-        ],
-        "total_count": 64,
-        "total_cost": 33.32
-    },
-    {
-        "instances": [
-            {
-                "count": 10,
-                "size": 1,
-                "total_cores": 10,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.5,
-                "available": 54
-            },
-            {
-                "count": 29,
-                "size": 2,
-                "total_cores": 58,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.77,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 11,
-                "size": 16,
-                "total_cores": 176,
-                "cost_per_instance": 1.1,
-                "instances_cost": 12.100000000000001,
-                "available": 43
-            },
-            {
-                "count": 11,
-                "size": 24,
-                "total_cores": 264,
-                "cost_per_instance": 1.52,
-                "instances_cost": 16.72,
-                "available": 41
-            }
-        ],
-        "total_count": 62,
-        "total_cost": 33.379999999999995
-    },
-    {
-        "instances": [
-            {
-                "count": 10,
-                "size": 1,
-                "total_cores": 10,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.5,
-                "available": 54
-            },
-            {
-                "count": 27,
-                "size": 2,
-                "total_cores": 54,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.5100000000000002,
-                "available": 51
-            },
-            {
-                "count": 13,
-                "size": 16,
-                "total_cores": 208,
-                "cost_per_instance": 1.1,
-                "instances_cost": 14.3,
-                "available": 43
-            },
-            {
-                "count": 10,
-                "size": 24,
-                "total_cores": 240,
-                "cost_per_instance": 1.52,
-                "instances_cost": 15.2,
-                "available": 41
-            }
-        ],
-        "total_count": 60,
-        "total_cost": 33.510000000000005
-    },
-    {
-        "instances": [
-            {
-                "count": 10,
-                "size": 1,
-                "total_cores": 10,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.5,
-                "available": 54
-            },
-            {
-                "count": 23,
-                "size": 2,
-                "total_cores": 46,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.99,
-                "available": 51
-            },
-            {
-                "count": 15,
-                "size": 16,
-                "total_cores": 240,
-                "cost_per_instance": 1.1,
-                "instances_cost": 16.5,
-                "available": 43
-            },
-            {
-                "count": 9,
-                "size": 24,
-                "total_cores": 216,
-                "cost_per_instance": 1.52,
-                "instances_cost": 13.68,
-                "available": 41
-            }
-        ],
-        "total_count": 57,
-        "total_cost": 33.67
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 24,
-                "size": 2,
-                "total_cores": 48,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.12,
-                "available": 51
-            },
-            {
-                "count": 15,
-                "size": 16,
-                "total_cores": 240,
-                "cost_per_instance": 1.1,
-                "instances_cost": 16.5,
-                "available": 43
-            },
-            {
-                "count": 9,
-                "size": 24,
-                "total_cores": 216,
-                "cost_per_instance": 1.52,
-                "instances_cost": 13.68,
-                "available": 41
-            }
-        ],
-        "total_count": 56,
-        "total_cost": 33.7
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 26,
-                "size": 2,
-                "total_cores": 52,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.38,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 16,
-                "size": 16,
-                "total_cores": 256,
-                "cost_per_instance": 1.1,
-                "instances_cost": 17.6,
-                "available": 43
-            },
-            {
-                "count": 8,
-                "size": 24,
-                "total_cores": 192,
-                "cost_per_instance": 1.52,
-                "instances_cost": 12.16,
-                "available": 41
-            }
-        ],
-        "total_count": 59,
-        "total_cost": 33.83
-    },
-    {
-        "instances": [
-            {
-                "count": 8,
-                "size": 1,
-                "total_cores": 8,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.4,
-                "available": 54
-            },
-            {
-                "count": 24,
-                "size": 2,
-                "total_cores": 48,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.12,
-                "available": 51
-            },
-            {
-                "count": 18,
-                "size": 16,
-                "total_cores": 288,
-                "cost_per_instance": 1.1,
-                "instances_cost": 19.8,
-                "available": 43
-            },
-            {
-                "count": 7,
-                "size": 24,
-                "total_cores": 168,
-                "cost_per_instance": 1.52,
-                "instances_cost": 10.64,
-                "available": 41
-            }
-        ],
-        "total_count": 57,
-        "total_cost": 33.96
-    },
-    {
-        "instances": [
-            {
-                "count": 6,
-                "size": 1,
-                "total_cores": 6,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.30000000000000004,
-                "available": 54
-            },
-            {
-                "count": 25,
-                "size": 2,
-                "total_cores": 50,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.25,
-                "available": 51
-            },
-            {
-                "count": 18,
-                "size": 16,
-                "total_cores": 288,
-                "cost_per_instance": 1.1,
-                "instances_cost": 19.8,
-                "available": 43
-            },
-            {
-                "count": 7,
-                "size": 24,
-                "total_cores": 168,
-                "cost_per_instance": 1.52,
-                "instances_cost": 10.64,
-                "available": 41
-            }
-        ],
-        "total_count": 56,
-        "total_cost": 33.99
-    },
-    {
-        "instances": [
-            {
-                "count": 6,
-                "size": 1,
-                "total_cores": 6,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.30000000000000004,
-                "available": 54
-            },
-            {
-                "count": 21,
-                "size": 2,
-                "total_cores": 42,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.73,
-                "available": 51
-            },
-            {
-                "count": 20,
-                "size": 16,
-                "total_cores": 320,
-                "cost_per_instance": 1.1,
-                "instances_cost": 22.0,
-                "available": 43
-            },
-            {
-                "count": 6,
-                "size": 24,
-                "total_cores": 144,
-                "cost_per_instance": 1.52,
-                "instances_cost": 9.120000000000001,
-                "available": 41
-            }
-        ],
-        "total_count": 53,
-        "total_cost": 34.150000000000006
-    },
-    {
-        "instances": [
-            {
-                "count": 6,
-                "size": 1,
-                "total_cores": 6,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.30000000000000004,
-                "available": 54
-            },
-            {
-                "count": 23,
-                "size": 2,
-                "total_cores": 46,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.99,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 21,
-                "size": 16,
-                "total_cores": 336,
-                "cost_per_instance": 1.1,
-                "instances_cost": 23.1,
-                "available": 43
-            },
-            {
-                "count": 5,
-                "size": 24,
-                "total_cores": 120,
-                "cost_per_instance": 1.52,
-                "instances_cost": 7.6,
-                "available": 41
-            }
-        ],
-        "total_count": 56,
-        "total_cost": 34.28
-    },
-    {
-        "instances": [
-            {
-                "count": 4,
-                "size": 1,
-                "total_cores": 4,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.2,
-                "available": 54
-            },
-            {
-                "count": 24,
-                "size": 2,
-                "total_cores": 48,
-                "cost_per_instance": 0.13,
-                "instances_cost": 3.12,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 21,
-                "size": 16,
-                "total_cores": 336,
-                "cost_per_instance": 1.1,
-                "instances_cost": 23.1,
-                "available": 43
-            },
-            {
-                "count": 5,
-                "size": 24,
-                "total_cores": 120,
-                "cost_per_instance": 1.52,
-                "instances_cost": 7.6,
-                "available": 41
-            }
-        ],
-        "total_count": 55,
-        "total_cost": 34.31
-    },
-    {
-        "instances": [
-            {
-                "count": 4,
-                "size": 1,
-                "total_cores": 4,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.2,
-                "available": 54
-            },
-            {
-                "count": 22,
-                "size": 2,
-                "total_cores": 44,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.8600000000000003,
-                "available": 51
             },
             {
                 "count": 1,
@@ -3498,24 +186,40 @@
                 "available": 45
             },
             {
-                "count": 21,
-                "size": 16,
-                "total_cores": 336,
-                "cost_per_instance": 1.1,
-                "instances_cost": 23.1,
-                "available": 43
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
             },
             {
-                "count": 5,
-                "size": 24,
-                "total_cores": 120,
-                "cost_per_instance": 1.52,
-                "instances_cost": 7.6,
-                "available": 41
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
             }
         ],
-        "total_count": 53,
-        "total_cost": 34.34
+        "total_count": 8,
+        "total_cost": 14.219999999999999
     },
     {
         "instances": [
@@ -3528,178 +232,274 @@
                 "available": 54
             },
             {
-                "count": 22,
-                "size": 2,
-                "total_cores": 44,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.8600000000000003,
-                "available": 51
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 14.239999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.23
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.33
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.36
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
             },
             {
                 "count": 3,
-                "size": 8,
-                "total_cores": 24,
-                "cost_per_instance": 0.58,
-                "instances_cost": 1.7399999999999998,
-                "available": 45
-            },
-            {
-                "count": 20,
-                "size": 16,
-                "total_cores": 320,
-                "cost_per_instance": 1.1,
-                "instances_cost": 22.0,
-                "available": 43
-            },
-            {
-                "count": 5,
-                "size": 24,
-                "total_cores": 120,
-                "cost_per_instance": 1.52,
-                "instances_cost": 7.6,
-                "available": 41
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
             }
         ],
-        "total_count": 54,
-        "total_cost": 34.4
+        "total_count": 5,
+        "total_cost": 14.469999999999999
     },
     {
         "instances": [
             {
-                "count": 4,
-                "size": 1,
-                "total_cores": 4,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.2,
-                "available": 54
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
             },
             {
-                "count": 22,
-                "size": 2,
-                "total_cores": 44,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.8600000000000003,
-                "available": 51
-            },
-            {
-                "count": 6,
-                "size": 8,
-                "total_cores": 48,
-                "cost_per_instance": 0.58,
-                "instances_cost": 3.4799999999999995,
-                "available": 45
-            },
-            {
-                "count": 20,
-                "size": 16,
-                "total_cores": 320,
-                "cost_per_instance": 1.1,
-                "instances_cost": 22.0,
-                "available": 43
-            },
-            {
-                "count": 4,
-                "size": 24,
+                "count": 1,
+                "size": 96,
                 "total_cores": 96,
-                "cost_per_instance": 1.52,
-                "instances_cost": 6.08,
-                "available": 41
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
             }
         ],
-        "total_count": 56,
-        "total_cost": 34.62
+        "total_count": 5,
+        "total_cost": 14.84
     },
     {
         "instances": [
             {
-                "count": 4,
-                "size": 1,
-                "total_cores": 4,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.2,
-                "available": 54
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
             },
             {
-                "count": 22,
-                "size": 2,
-                "total_cores": 44,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.8600000000000003,
-                "available": 51
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
             },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.879999999999999
+    },
+    {
+        "instances": [
             {
                 "count": 8,
-                "size": 8,
-                "total_cores": 64,
-                "cost_per_instance": 0.58,
-                "instances_cost": 4.64,
-                "available": 45
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
             },
             {
-                "count": 19,
-                "size": 16,
-                "total_cores": 304,
-                "cost_per_instance": 1.1,
-                "instances_cost": 20.900000000000002,
-                "available": 43
-            },
-            {
-                "count": 4,
+                "count": 1,
                 "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 96,
                 "total_cores": 96,
-                "cost_per_instance": 1.52,
-                "instances_cost": 6.08,
-                "available": 41
-            }
-        ],
-        "total_count": 57,
-        "total_cost": 34.68
-    },
-    {
-        "instances": [
-            {
-                "count": 4,
-                "size": 1,
-                "total_cores": 4,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.2,
-                "available": 54
-            },
-            {
-                "count": 22,
-                "size": 2,
-                "total_cores": 44,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.8600000000000003,
-                "available": 51
-            },
-            {
-                "count": 11,
-                "size": 8,
-                "total_cores": 88,
-                "cost_per_instance": 0.58,
-                "instances_cost": 6.38,
-                "available": 45
-            },
-            {
-                "count": 19,
-                "size": 16,
-                "total_cores": 304,
-                "cost_per_instance": 1.1,
-                "instances_cost": 20.900000000000002,
-                "available": 43
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
             },
             {
                 "count": 3,
-                "size": 24,
-                "total_cores": 72,
-                "cost_per_instance": 1.52,
-                "instances_cost": 4.5600000000000005,
-                "available": 41
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
             }
         ],
-        "total_count": 59,
-        "total_cost": 34.900000000000006
+        "total_count": 13,
+        "total_cost": 14.91
     },
     {
         "instances": [
@@ -3712,412 +512,410 @@
                 "available": 54
             },
             {
-                "count": 21,
-                "size": 2,
-                "total_cores": 42,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.73,
-                "available": 51
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
             },
             {
                 "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
             },
             {
-                "count": 11,
-                "size": 8,
-                "total_cores": 88,
-                "cost_per_instance": 0.58,
-                "instances_cost": 6.38,
-                "available": 45
-            },
-            {
-                "count": 19,
-                "size": 16,
-                "total_cores": 304,
-                "cost_per_instance": 1.1,
-                "instances_cost": 20.900000000000002,
-                "available": 43
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
             },
             {
                 "count": 3,
-                "size": 24,
-                "total_cores": 72,
-                "cost_per_instance": 1.52,
-                "instances_cost": 4.5600000000000005,
-                "available": 41
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
             }
         ],
-        "total_count": 57,
-        "total_cost": 34.96
+        "total_count": 8,
+        "total_cost": 14.96
     },
     {
         "instances": [
             {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 21,
-                "size": 2,
-                "total_cores": 42,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.73,
-                "available": 51
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
             },
             {
                 "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 13,
-                "size": 8,
-                "total_cores": 104,
-                "cost_per_instance": 0.58,
-                "instances_cost": 7.539999999999999,
-                "available": 45
-            },
-            {
-                "count": 18,
-                "size": 16,
-                "total_cores": 288,
-                "cost_per_instance": 1.1,
-                "instances_cost": 19.8,
-                "available": 43
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
             },
             {
                 "count": 3,
-                "size": 24,
-                "total_cores": 72,
-                "cost_per_instance": 1.52,
-                "instances_cost": 4.5600000000000005,
-                "available": 41
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
             }
         ],
-        "total_count": 58,
-        "total_cost": 35.02
+        "total_count": 5,
+        "total_cost": 15.57
     },
     {
         "instances": [
             {
                 "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 21,
-                "size": 2,
-                "total_cores": 42,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.73,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 16,
-                "size": 8,
-                "total_cores": 128,
-                "cost_per_instance": 0.58,
-                "instances_cost": 9.28,
-                "available": 45
-            },
-            {
-                "count": 18,
-                "size": 16,
-                "total_cores": 288,
-                "cost_per_instance": 1.1,
-                "instances_cost": 19.8,
-                "available": 43
-            },
-            {
-                "count": 2,
-                "size": 24,
-                "total_cores": 48,
-                "cost_per_instance": 1.52,
-                "instances_cost": 3.04,
-                "available": 41
-            }
-        ],
-        "total_count": 60,
-        "total_cost": 35.24
-    },
-    {
-        "instances": [
-            {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 19,
-                "size": 2,
-                "total_cores": 38,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.47,
-                "available": 51
-            },
-            {
-                "count": 17,
-                "size": 8,
-                "total_cores": 136,
-                "cost_per_instance": 0.58,
-                "instances_cost": 9.86,
-                "available": 45
-            },
-            {
-                "count": 18,
-                "size": 16,
-                "total_cores": 288,
-                "cost_per_instance": 1.1,
-                "instances_cost": 19.8,
-                "available": 43
-            },
-            {
-                "count": 2,
-                "size": 24,
-                "total_cores": 48,
-                "cost_per_instance": 1.52,
-                "instances_cost": 3.04,
-                "available": 41
-            }
-        ],
-        "total_count": 58,
-        "total_cost": 35.27
-    },
-    {
-        "instances": [
-            {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 19,
-                "size": 2,
-                "total_cores": 38,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.47,
-                "available": 51
-            },
-            {
-                "count": 19,
-                "size": 8,
-                "total_cores": 152,
-                "cost_per_instance": 0.58,
-                "instances_cost": 11.02,
-                "available": 45
-            },
-            {
-                "count": 17,
-                "size": 16,
-                "total_cores": 272,
-                "cost_per_instance": 1.1,
-                "instances_cost": 18.700000000000003,
-                "available": 43
-            },
-            {
-                "count": 2,
-                "size": 24,
-                "total_cores": 48,
-                "cost_per_instance": 1.52,
-                "instances_cost": 3.04,
-                "available": 41
-            }
-        ],
-        "total_count": 59,
-        "total_cost": 35.330000000000005
-    },
-    {
-        "instances": [
-            {
-                "count": 2,
-                "size": 1,
-                "total_cores": 2,
-                "cost_per_instance": 0.05,
-                "instances_cost": 0.1,
-                "available": 54
-            },
-            {
-                "count": 19,
-                "size": 2,
-                "total_cores": 38,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.47,
-                "available": 51
-            },
-            {
-                "count": 22,
-                "size": 8,
-                "total_cores": 176,
-                "cost_per_instance": 0.58,
-                "instances_cost": 12.76,
-                "available": 45
-            },
-            {
-                "count": 17,
-                "size": 16,
-                "total_cores": 272,
-                "cost_per_instance": 1.1,
-                "instances_cost": 18.700000000000003,
-                "available": 43
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            }
-        ],
-        "total_count": 61,
-        "total_cost": 35.550000000000004
-    },
-    {
-        "instances": [
-            {
-                "count": 20,
-                "size": 2,
-                "total_cores": 40,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.6,
-                "available": 51
-            },
-            {
-                "count": 22,
-                "size": 8,
-                "total_cores": 176,
-                "cost_per_instance": 0.58,
-                "instances_cost": 12.76,
-                "available": 45
-            },
-            {
-                "count": 17,
-                "size": 16,
-                "total_cores": 272,
-                "cost_per_instance": 1.1,
-                "instances_cost": 18.700000000000003,
-                "available": 43
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            }
-        ],
-        "total_count": 60,
-        "total_cost": 35.580000000000005
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 2,
-                "total_cores": 36,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.34,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 22,
-                "size": 8,
-                "total_cores": 176,
-                "cost_per_instance": 0.58,
-                "instances_cost": 12.76,
-                "available": 45
-            },
-            {
-                "count": 17,
-                "size": 16,
-                "total_cores": 272,
-                "cost_per_instance": 1.1,
-                "instances_cost": 18.700000000000003,
-                "available": 43
-            },
-            {
-                "count": 1,
-                "size": 24,
-                "total_cores": 24,
-                "cost_per_instance": 1.52,
-                "instances_cost": 1.52,
-                "available": 41
-            }
-        ],
-        "total_count": 59,
-        "total_cost": 35.61000000000001
-    },
-    {
-        "instances": [
-            {
-                "count": 18,
-                "size": 2,
-                "total_cores": 36,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.34,
-                "available": 51
-            },
-            {
-                "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
-            },
-            {
-                "count": 24,
-                "size": 8,
+                "size": 96,
                 "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.71
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.91
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 20,
+        "total_cost": 20.090000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 20.12
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 20.080000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 20.18
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 20.18
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
                 "cost_per_instance": 0.58,
-                "instances_cost": 13.919999999999998,
+                "instances_cost": 0.58,
                 "available": 45
             },
             {
-                "count": 16,
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 20.270000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 20.290000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 20.450000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
                 "size": 16,
-                "total_cores": 256,
+                "total_cores": 16,
                 "cost_per_instance": 1.1,
-                "instances_cost": 17.6,
+                "instances_cost": 1.1,
                 "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 20.490000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
             },
             {
                 "count": 1,
@@ -4126,85 +924,113 @@
                 "cost_per_instance": 1.52,
                 "instances_cost": 1.52,
                 "available": 41
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
             }
         ],
-        "total_count": 60,
-        "total_cost": 35.67
+        "total_count": 14,
+        "total_cost": 20.520000000000003
     },
     {
         "instances": [
             {
-                "count": 18,
-                "size": 2,
-                "total_cores": 36,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.34,
-                "available": 51
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
             },
             {
                 "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
             },
             {
-                "count": 27,
-                "size": 8,
-                "total_cores": 216,
-                "cost_per_instance": 0.58,
-                "instances_cost": 15.659999999999998,
-                "available": 45
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
             },
             {
-                "count": 16,
-                "size": 16,
-                "total_cores": 256,
-                "cost_per_instance": 1.1,
-                "instances_cost": 17.6,
-                "available": 43
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
             }
         ],
-        "total_count": 62,
-        "total_cost": 35.89
+        "total_count": 9,
+        "total_cost": 20.57
     },
     {
         "instances": [
             {
-                "count": 18,
-                "size": 2,
-                "total_cores": 36,
-                "cost_per_instance": 0.13,
-                "instances_cost": 2.34,
-                "available": 51
-            },
-            {
                 "count": 1,
-                "size": 4,
-                "total_cores": 4,
-                "cost_per_instance": 0.29,
-                "instances_cost": 0.29,
-                "available": 52
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
             },
             {
-                "count": 29,
-                "size": 8,
-                "total_cores": 232,
-                "cost_per_instance": 0.58,
-                "instances_cost": 16.82,
-                "available": 45
-            },
-            {
-                "count": 15,
-                "size": 16,
-                "total_cores": 240,
-                "cost_per_instance": 1.1,
-                "instances_cost": 16.5,
-                "available": 43
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
             }
         ],
-        "total_count": 63,
-        "total_cost": 35.95
+        "total_count": 6,
+        "total_cost": 21.18
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 96,
+                "total_cores": 576,
+                "cost_per_instance": 3.72,
+                "instances_cost": 22.32,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.32
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.520000000000003
     }
 ]

--- a/aws/spot-instances/run2/spot-instance-choices.json
+++ b/aws/spot-instances/run2/spot-instance-choices.json
@@ -648,6 +648,1128 @@
                 "available": 3
             },
             {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 14.48
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 18,
+        "total_cost": 14.51
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.66
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.68
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.6
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.62
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.99
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.19
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 16.39
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 16.42
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 16.48
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.57
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 16.59
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.58
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.68
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 16.82
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.95
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.97
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.990000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.990000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.34
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.54
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
                 "count": 5,
                 "size": 96,
                 "total_cores": 480,
@@ -1000,20 +2122,6 @@
     {
         "instances": [
             {
-                "count": 6,
-                "size": 96,
-                "total_cores": 576,
-                "cost_per_instance": 3.72,
-                "instances_cost": 22.32,
-                "available": 10
-            }
-        ],
-        "total_count": 6,
-        "total_cost": 22.32
-    },
-    {
-        "instances": [
-            {
                 "count": 1,
                 "size": 64,
                 "total_cores": 64,
@@ -1032,5 +2140,1767 @@
         ],
         "total_count": 6,
         "total_cost": 22.520000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.620000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 15.95
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 15.98
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.04
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.15
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.23
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.34
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.380000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.439999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.71
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.73
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.3
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.97
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 18.3
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 18.33
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 18.39
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.5
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.58
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 36,
+                "total_cores": 288,
+                "cost_per_instance": 1.48,
+                "instances_cost": 11.84,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 18.65
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 18.689999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 18.73
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.79
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 19.060000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 19.08
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 19.099999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 19.099999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 19.650000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 96,
+                "total_cores": 576,
+                "cost_per_instance": 3.72,
+                "instances_cost": 22.32,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.32
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 20.21
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.240000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.4
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.61
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 20.619999999999997
+    },
+    {
+        "instances": [
+            {
+                "count": 9,
+                "size": 36,
+                "total_cores": 324,
+                "cost_per_instance": 1.48,
+                "instances_cost": 13.32,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 20.76
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 36,
+                "total_cores": 144,
+                "cost_per_instance": 1.48,
+                "instances_cost": 5.92,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 20.8
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 20.84
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.9
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 21.17
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 21.19
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 21.21
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 21.21
     }
 ]

--- a/aws/spot-instances/run2/spot_instances.py
+++ b/aws/spot-instances/run2/spot_instances.py
@@ -12,11 +12,10 @@
 
 import argparse
 import os
-import sys
 import statistics
+import sys
 
 import pandas
-
 from cloudselect.logger import setup_logger
 from cloudselect.main import Client
 

--- a/aws/spot-instances/run2/spot_instances.py
+++ b/aws/spot-instances/run2/spot_instances.py
@@ -11,6 +11,7 @@
 # However it needs a certain instance type and number
 
 import argparse
+import boto3
 import os
 import statistics
 import sys
@@ -49,6 +50,7 @@ def get_parser():
     gen.add_argument(
         "--no-cache", help="do not use cache", action="store_true", default=False
     )
+    gen.add_argument("--region", help="set region for cloud", default="us-east-1")
 
     # On the fly updates to config params
     gen.add_argument(
@@ -312,8 +314,20 @@ def generate_data(args):
         # Spot instances are aws for now
         if cloud.name != "aws":
             continue
-        instances = cli.instances()["aws"]
-        prices = cli.prices()["aws"]
+
+        # if we don't update the boto clients, we won't get instance results
+        cloud.regions = [args.region]
+        cloud.ec2_client = boto3.client("ec2", region_name=args.region)
+        cloud.pricing_cli = boto3.client("pricing", region_name=args.region)
+
+        # TODO need to check why instances doesn't work
+        if args.no_cache:
+            instances = cloud.instances()
+            prices = cloud.prices()
+
+        else:
+            instances = cli.instances()["aws"]
+            prices = cli.prices()["aws"]
 
         # Get spot prices
         spot_prices = cloud.spot_prices(instances)

--- a/aws/spot-instances/run2/test_optimize.py
+++ b/aws/spot-instances/run2/test_optimize.py
@@ -5,6 +5,7 @@
 
 import argparse
 import os
+import copy
 import sys
 import math
 import scipy.optimize
@@ -82,6 +83,319 @@ def get_parser():
     return parser
 
 
+class PotpourriOptimizer:
+    def __init__(
+        self,
+        cores,
+        data_file,
+        bare_metal=False,
+        hypervisor="nitro",
+        has_gpu=False,
+        arch="x86_64",
+        region="us-east-2",
+        min_score=9,
+        linprog_method="highs",
+    ):
+        """
+        The Potpourri optimizer holds a data frame of instances to
+        select from, current bounds, parameters, and the optimizer function.
+        """
+        # Be generous with initial selection, select specific hypervisor and not bare metal
+        # We assume we don't want the user changing this again, so we don't expose beyond init
+        self.cores = cores
+        self.region = region
+        self.min_score = min_score
+        self.linprog_method = linprog_method
+        self.df = spot_cli.select_instances(
+            data_file,
+            bare_metal=bare_metal,
+            hypervisor=hypervisor,
+            has_gpu=has_gpu,
+            arch=arch,
+        )
+
+        # Calculate all values we need on setup. Again, we assume that the optimizer is
+        # not allowed to change values mid-usage (without creating a new instance)
+        self.setup()
+
+        # Calculate max instances needed for cores wanted
+        self.calculate_max_instances()
+
+        # Initialize bounds
+        self.set_params()
+
+    def run(self, reset_bounds=False):
+        """
+        Run the algorithm!
+        """
+        if reset_bounds:
+            self.bounds = copy.deepcopy(self.original_bounds)
+
+        # Note that we can set a callback to print steps
+        return scipy.optimize.linprog(
+            self.costs,
+            A_ub=self.A,
+            b_ub=self.b_ub,
+            bounds=self.bounds,
+            integrality=self.integrality,
+            method=self.linprog_method,
+        )
+
+    def set_params(self):
+        """
+        Set initial parameters. Aside from bounds (that can be reset)
+        these do not change.
+        """
+        self.set_bounds()
+
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html
+        # I think we want a subset of instances s.t.:
+        # count(instances) < max_instances, and sum(cores) > asked_cores
+        # and we have to set max_instances across a range, because the optimization
+        # will always choose smaller ones! They are always cheaper (weird)
+        # Can this just be a linear problem?
+        #   x is the number of instances of each type
+        #   c is the cost of each type of instance
+        #   l and u are min and max instances of each type
+        #   A can be a row matrix of all 1s
+        # A * x = [1, 1, ..., 1] [x_1, x_2, ... x_N]^T = x_1 + x_2 + ... + x_N
+        self.costs = list(self.mean_costs.values())
+
+        # Let's set A_ub to a numpy array
+        # First row is all ones, this just counts the instances
+        A1 = len(self.costs) * [1]
+
+        # second row is negative of the number of cores per instance
+        # it has to be negative because inequality has to be flipped
+        A2 = [x * -1 for x in self.sizes]
+        self.A = [A1, A2]
+
+        # b_ub is a 1-D array with just two values:
+        # the maximum number of instances (the same as the cores, if we select sizes of 1)
+        # and NEGATIVE the minimum number of cores (again, inequality is flipped)
+        self.b_ub = [self.cores, -1 * self.cores]
+
+        # The function assumes less than or equal to, but for cores we want greater or equal to
+        # If we want to set an upper bound on cores we would have a third row
+        # This would say "Must be 0 or greater (all of them)"
+        # bounds = (0, None)
+        # But I think we want to bound based on selection of instance types available.
+
+        # Must be integer values
+        self.integrality = 1
+
+    def set_bounds(self):
+        """
+        Assemble a min (0) and max instances for each size!
+        Note that this goes only up to the size we generated above.
+        We could fudge a little bit.
+        """
+        self.bounds = []
+        for size in self.sizes:
+            self.bounds.append((0, self.max_instances[size]))
+
+        # Save the original bounds for reset later
+        self.original_bounds = copy.deepcopy(self.bounds)
+
+    def calculate_max_instances(self):
+        """
+        We want to create a maximum quantity we should ask for each based on spot score
+        we use the spot scores API to find a count that corresponds with our
+        risk tolerance. The API returns max value 9 (very likely) to 1 (unlikely)
+        """
+        cli = Client(use_cache=True, clouds=["aws"])
+
+        # Get new prices data for each cloud
+        cloud = cli.get_clouds()[0]
+        cloud._set_services()
+
+        # Start with quota (only 50)
+        have_quota = True
+
+        # Create a maximum quantity we should ask for each based on spot score
+        # we use the spot scores API to find a count that corresponds with our
+        # risk tolerance. The API returns max value 9 (very likely) to 1 (unlikely)
+        self.max_instances = {}
+        for core, count in self.needed_counts.items():
+            # We can only ask for a max estimate of 50
+            if count > 50:
+                count = 50
+
+            if not have_quota:
+                break
+
+            # Just put this here for testing, or if we ever get a cache
+            if core in self.max_instances:
+                continue
+
+            # Get instance types for this size
+            instance_types = self.df[self.df.cores == core].instance.tolist()
+
+            # Step 1: Calculate the max number of instances we might choose for the type
+            while have_quota and count > 0:
+                print(f"Getting spot score for instances of size {core}")
+                try:
+                    score = cloud.ec2_client.get_spot_placement_scores(
+                        InstanceTypes=instance_types,
+                        RegionNames=[self.region],
+                        TargetCapacity=count,
+                        TargetCapacityUnitType="units",
+                    )
+                except Exception as e:
+                    print(f"Hit an error: {e}, likely out of quota")
+                    have_quota = False
+                    break
+
+                # If the score is == our risk tolerance, we are good!
+                score = score["SpotPlacementScores"][0]["Score"]
+
+                # If we are in the risk tolerance, break from the while
+                if score >= self.min_score:
+                    print(
+                        f"✅️ Spot score: size {core}     [satisfed]: {count} instances (score: {score})"
+                    )
+                    self.max_instances[core] = count
+                    break
+
+                # We don't have a lot of queries, so decrease by 1/3
+                # if score < args.min_score:
+                # Take the maximum of 1 and current minus 1/3
+                print(
+                    f"❌️ Spot score: size {core} [not-satisfed]: {count} instances (score: {score})"
+                )
+                count = max(1, count - math.ceil(1 / 3 * count))
+
+    def setup(self):
+        """
+        Run initial setup, or caching of values we will need later.
+
+        This should only be done once.
+        """
+        # Calculate the price / cores
+        self.df["price_per_core"] = self.df.spot_price / self.df.cores
+
+        # This was just for my viewing
+        # sorted_df = df.sort_values(["price_per_core", "cores"])
+        self.mean_costs = {}
+        self.mean_costs_per_core = {}
+
+        # Let's keep track of the number available for each.
+        # We don't generally want to trust a size with less than 4.
+        self.available = {}
+
+        # We also will calculate the min number of instances needed for each type
+        self.needed_counts = {}
+
+        # Get mean value for each (to minimize)
+        # The second was just for my FYI, for example when we don't set bounds,
+        # the optimizer chooses 4 x 128, which has the cheapest cost / core
+        for core in self.unique_cores:
+            self.mean_costs[core] = self.df[self.df.cores == core].spot_price.mean()
+            self.mean_costs_per_core[core] = self.df[
+                self.df.cores == core
+            ].price_per_core.mean()
+            self.available[core] = self.df[self.df.cores == core].shape[0]
+            # Take a ceiling, having a little extra is OK
+            self.needed_counts[core] = math.ceil(self.cores / core)
+
+        # We will use order of sizes to calculate bounds (from spot score api)
+        self.sizes = list(self.mean_costs.keys())
+
+    def remove_cheapest(self, result):
+        """
+        If we get stuck in a loop with the cheapest, remove it
+        by setting the max bounds to 0.
+        """
+        idx = self.find_highest_cost_index(result, [], adjust_cheapest=True)
+        self.bounds[idx] = (0, 0)
+
+    def find_highest_cost_index(self, result, ignores, adjust_cheapest=False):
+        """
+        Given a result, we want to decrement the max bound for the most
+        expensive option cost PER core. This will (hopefully) force the
+        algorithm to choose an option with a better cost per core.
+        """
+        # If we change the most expensive, we want to reverse
+        # If we adjust the cheapest (True) we don't want to reverse (cheapest at top)
+        reverse = adjust_cheapest is False
+
+        # Determine the most expensive per core hour. First, these are indices of chosen
+        # ignores takes into account indices that we need to ignore (e.g, bounds zeroed out)
+        chosen_idx = [
+            i for i, x in enumerate(result.x) if int(round(x)) != 0 and i not in ignores
+        ]
+        chosen_sizes = [self.sizes[idx] for idx in chosen_idx]
+
+        # Given the chosen sizes, filter down the mean price per core, and sort highest to lowest
+        subset_mppc = {x: self.mean_costs_per_core[x] for x in chosen_sizes}
+        subset_mppc = {
+            k: v
+            for k, v in sorted(
+                subset_mppc.items(), key=lambda item: item[1], reverse=reverse
+            )
+        }
+
+        # This is the highest price, the size if adjust cheapest
+        chosen_size = list(subset_mppc.keys())[0]
+
+        # Return the index of the highest price
+        return self.sizes.index(chosen_size)
+
+    @property
+    def unique_cores(self):
+        """
+        Unique quantities of cores, and mean cost by size
+        """
+        return self.df.cores.unique().tolist()
+
+    def show_result(self, result):
+        """
+        Helper function to show a result.
+
+        Note that no result data should be stored with this class.
+        """
+        # One result might have multiple instances
+        single_result = {"instances": []}
+        total_cost = 0
+        total_count = 0
+
+        # Create a unique id so we know if we've seen it before
+        uid = ""
+        for i, count in enumerate(result.x):
+            size = self.sizes[i]
+
+            # IMPORTANT: the result looks like an int, but is a long float
+            # This might introduce error, look at again at some point
+            count = int(round(count))
+            if count != 0:
+                if uid:
+                    uid += f"-{size}-{count}"
+                else:
+                    uid = f"{size}-{count}"
+
+                # Cost for this set of instances
+                cost_per_instance = round(self.mean_costs[size], 2)
+                instances_cost = count * round(cost_per_instance, 2)
+                total_cost += instances_cost
+                total_count += count
+                single_result["instances"].append(
+                    {
+                        "count": count,
+                        "size": size,
+                        "total_cores": count * size,
+                        "cost_per_instance": cost_per_instance,
+                        "instances_cost": instances_cost,
+                        "available": self.available[size],
+                    }
+                )
+
+        single_result["uid"] = uid
+        single_result["total_count"] = total_count
+        single_result["total_cost"] = total_cost
+        total_cost = round(total_cost, 2)
+        return single_result
+
+
 def main():
     """
     Run experiments for lammps, and collect hwloc info.
@@ -89,7 +403,6 @@ def main():
     # Strategy 1: calculate the cheapest cost / cpu to filter down instance sizes
     # Manually derived equation for now, based on mean prices
     # import the script we have two levels up
-
     parser = get_parser()
 
     # If an error occurs while parsing the arguments, the interpreter will exit with value 2
@@ -99,159 +412,21 @@ def main():
     if not args.cores:
         sys.exit("Number of cores for analysis is required.")
 
-    # Be generous with initial selection, select specific hypervisor and not bare metal
-    df = spot_cli.select_instances(
+    # Create a potpourri optimizer! I shall call him "poo"
+    poo = PotpourriOptimizer(
+        args.cores,
         data_file,
         bare_metal=args.bare_metal,
         hypervisor=args.hypervisor,
         has_gpu=args.has_gpu,
         arch=args.arch,
+        region=args.region,
+        min_score=args.min_score,
+        linprog_method=args.linprog_method,
     )
 
-    # Calculate the price / cores
-    df["price_per_core"] = df.spot_price / df.cores
-    # This was just for my viewing
-    # sorted_df = df.sort_values(["price_per_core", "cores"])
-
-    # Unique quantities of cores, and mean cost by size
-    unique_cores = df.cores.unique().tolist()
-    mean_costs_per_core = {}
-    mean_costs = {}
-
-    # Let's keep track of the number available for each.
-    # We don't generally want to trust a size with less than 4.
-    available = {}
-
-    # We also will calculate the min number of instances needed for each type
-    needed_counts = {}
-
-    # Get mean value for each (to minimize)
-    # The second was just for my FYI, for example when we don't set bounds,
-    # the optimizer chooses 4 x 128, which has the cheapest cost / core
-    for core in unique_cores:
-        mean_costs[core] = df[df.cores == core].spot_price.mean()
-        mean_costs_per_core[core] = df[df.cores == core].price_per_core.mean()
-        available[core] = df[df.cores == core].shape[0]
-        # Take a ceiling, having a little extra is OK
-        needed_counts[core] = math.ceil(args.cores / core)
-
-    # We will use order of sizes to calculate bounds (from spot score api)
-    sizes = list(mean_costs.keys())
-    cli = Client(use_cache=True, clouds=["aws"])
-
-    # Get new prices data for each cloud
-    cloud = cli.get_clouds()[0]
-    cloud._set_services()
-
-    # Start with quota (only 50)
-    have_quota = True
-
-    # Create a maximum quantity we should ask for each based on spot score
-    # we use the spot scores API to find a count that corresponds with our
-    # risk tolerance. The API returns max value 9 (very likely) to 1 (unlikely)
-    max_instances = {}
-    for core, count in needed_counts.items():
-        # We can only ask for a max estimate of 50
-        if count > 50:
-            count = 50
-
-        if not have_quota:
-            break
-
-        # Just put this here for testing, or if we ever get a cache
-        if core in max_instances:
-            continue
-
-        # Get instance types for this size
-        instance_types = df[df.cores == core].instance.tolist()
-
-        # Step 1: Calculate the max number of instances we might choose for the type
-        while have_quota and count > 0:
-            print(f"Getting spot score for instances of size {core}")
-            try:
-                score = cloud.ec2_client.get_spot_placement_scores(
-                    InstanceTypes=instance_types,
-                    RegionNames=[args.region],
-                    TargetCapacity=count,
-                    TargetCapacityUnitType="units",
-                )
-            except Exception as e:
-                print(f"Hit an error: {e}, likely out of quota")
-                have_quota = False
-                break
-
-            # If the score is == our risk tolerance, we are good!
-            score = score["SpotPlacementScores"][0]["Score"]
-
-            # If we are in the risk tolerance, break from the while
-            if score >= args.min_score:
-                print(
-                    f"✅️ Spot score: size {core}     [satisfed]: {count} instances (score: {score})"
-                )
-                max_instances[core] = count
-                break
-
-            # We don't have a lot of queries, so decrease by 1/3
-            # But take
-            # if score < args.min_score:
-            # Take the maximum of 1 and current minus 1/3
-            print(
-                f"❌️ Spot score: size {core} [not-satisfed]: {count} instances (score: {score})"
-            )
-            count = max(1, count - math.ceil(1 / 3 * count))
-
-    # Now assemble a min (0) and max instances for each size!
-    # Note that this goes only up to the size we generated above.
-    # We could fudge a little bit.
-    bounds = []
-    for size in sizes:
-        bounds.append((0, max_instances[size]))
-
-    # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html
-    # I think we want a subset of instances s.t.:
-    # count(instances) < max_instances, and sum(cores) > asked_cores
-    # and we have to set max_instances across a range, because the optimization
-    # will always choose smaller ones! They are always cheaper (weird)
-    # Can this just be a linear problem?
-    #   x is the number of instances of each type
-    #   c is the cost of each type of instance
-    #   l and u are min and max instances of each type
-    #   A can be a row matrix of all 1s
-    # A * x = [1, 1, ..., 1] [x_1, x_2, ... x_N]^T = x_1 + x_2 + ... + x_N
-    costs = list(mean_costs.values())
-
-    # Let's set A_ub to a numpy array
-    # First row is all ones, this just counts the instances
-    A1 = len(costs) * [1]
-    # second row is negative of the number of cores per instance
-    # it has to be negative because inequality has to be flipped
-    A2 = [x * -1 for x in sizes]
-    A = [A1, A2]
-
-    # b_ub is a 1-D array with just two values:
-    # the maximum number of instances (the same as the cores, if we select sizes of 1)
-    # and NEGATIVE the minimum number of cores (again, inequality is flipped)
-    b_ub = [args.cores, -1 * args.cores]
-
-    # The function assumes less than or equal to, but for cores we want greater or equal to
-    # If we want to set an upper bound on cores we would have a third row
-    # This would say "Must be 0 or greater (all of them)"
-    # bounds = (0, None)
-    # But I think we want to bound based on selection of instance types available.
-
-    # Must be integer values
-    integrality = 1
-
-    # Try it out?
-    # Note that we can set a callback to print steps
-    result = scipy.optimize.linprog(
-        costs,
-        A_ub=A,
-        b_ub=b_ub,
-        bounds=bounds,
-        integrality=integrality,
-        method=args.linprog_method,
-    )
+    # Run the initial algorithm! This gives us a first result to start from
+    result = poo.run()
 
     # Save json dict of results
     results = []
@@ -259,49 +434,84 @@ def main():
     # Keep track of results we have seen
     seen = set()
 
+    # The top result is always added, we haven't seen it yet!
     print(result)
     print("\n⭐️ Suggested top request (accounting for price and spot scores):")
     for i, count in enumerate(result.x):
-        res = show_result(result, sizes, mean_costs, available)
+        res = poo.show_result(result)
         if res and res["uid"] not in seen:
             seen.add(res["uid"])
             del res["uid"]
             print_result(res)
             results.append(res)
 
-    print("\nCalculating remainder of results (total {args.results})")
+    print(f"\nCalculating remainder of results (total {args.results})")
     args.results -= 1
+
+    # Always decrement the most expensive, unless we run out of options
+    adjust_cheapest = False
+
+    # If we are unsuccesful twice, remove the cheapest option entirely
+    unsuccess_count = 0
 
     # Find the first non-zero, and decrease by one in the bounds
     while args.results > 0:
-        for i, count in enumerate(result.x):
-            if count != 0:
-                bound = bounds[i]
+        # Find the index into sizes (where a choice was made) with the highest cost per core
+        # In case we cannot decrement a bound, we allow this to loop
+        ignores = set()
+        while True:
+            # Two unsuccessful means we weren't successful to remove cheapest, remove entirely
+            if unsuccess_count >= 2 and adjust_cheapest:
+                poo.remove_cheapest(result)
+                result = poo.run()
 
-                # We can't go any lower, we've eliminated this
-                if bound[1] <= 0:
-                    continue
+            idx = poo.find_highest_cost_index(result, ignores, adjust_cheapest)
+            bound = poo.bounds[idx]
 
-                # If we get here, decrease the bound by 1
-                bounds[i] = (bound[0], bound[1] - 1)
+            # We can't go any lower, we've eliminated this
+            if bound[1] <= 0:
+                ignores.add(idx)
+                continue
 
-                # Calculate the new result (with new bounds)
-                # It might have different sets of instances
-                result = scipy.optimize.linprog(
-                    costs,
-                    A_ub=A,
-                    b_ub=b_ub,
-                    bounds=bounds,
-                    integrality=integrality,
-                    method=args.linprog_method,
-                )
-                res = show_result(result, sizes, mean_costs, available)
-                if res and res["uid"] not in seen:
-                    seen.add(res["uid"])
-                    del res["uid"]
-                    print_result(res)
-                    results.append(res)
-                    args.results -= 1
+            # If we get here, break out of while!
+            break
+
+        if unsuccess_count >= 5:
+            print("Likely hit local solution, exiting!")
+            args.results = 0
+            break
+
+        # If we get here, we have a valid index, and decrease the bound by 1
+        poo.bounds[idx] = (bound[0], bound[1] - 1)
+
+        # Calculate the new result (with new bounds)
+        # It might have different sets of instances
+        result = poo.run()
+
+        # We currently remove the highest cost per core already. This biases to always keep the lowest.
+        # This means all solutions will have the lowest cost per core, because we don't want to remove it
+        # But if we remove enough more expensive, we eventually run out. When this happens this errors.
+        # And we should restore our original bounds, but allow decrement of the cheapest by one
+        # This will force other solutions that fill the space of the previous cheapest one
+        # If we set it to 0, we could be more aggressive and get very different (more expensive) answers
+        if not result.success:
+            print(
+                "Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest."
+            )
+            result = poo.run(reset_bounds=True)
+            unsuccess_count += 1
+            adjust_cheapest = True
+            continue
+
+        # If we make it here (success) go back to decrement of max cost instance!
+        adjust_cheapest = False
+        res = poo.show_result(result)
+        if res and res["uid"] not in seen:
+            seen.add(res["uid"])
+            del res["uid"]
+            print_result(res)
+            results.append(res)
+            args.results -= 1
 
     print(f"Saving results to {args.outfile}")
     utils.write_json(results, args.outfile)
@@ -310,53 +520,6 @@ def main():
 def print_result(res):
     total_cost = round(res["total_cost"], 1)
     print(f"  => Result: 💰️ ${total_cost} for {len(res['instances'])} instances.")
-
-
-def show_result(result, sizes, mean_costs, available):
-    """
-    Given a count, size, and mean costs,
-    print the nice result for the user!
-    """
-    # One result might have multiple instances
-    single_result = {"instances": []}
-    total_cost = 0
-    total_count = 0
-
-    # Create a unique id so we know if we've seen it before
-    uid = ""
-    for i, count in enumerate(result.x):
-        size = sizes[i]
-
-        # IMPORTANT: the result looks like an int, but is a long float
-        # This might introduce error, look at again at some point
-        count = int(round(count))
-        if count != 0:
-            if uid:
-                uid += f"-{size}-{count}"
-            else:
-                uid = f"{size}-{count}"
-
-            # Cost for this set of instances
-            cost_per_instance = round(mean_costs[size], 2)
-            instances_cost = count * round(cost_per_instance, 2)
-            total_cost += instances_cost
-            total_count += count
-            single_result["instances"].append(
-                {
-                    "count": count,
-                    "size": size,
-                    "total_cores": count * size,
-                    "cost_per_instance": cost_per_instance,
-                    "instances_cost": instances_cost,
-                    "available": available[size],
-                }
-            )
-
-    single_result["uid"] = uid
-    single_result["total_count"] = total_count
-    single_result["total_cost"] = total_cost
-    total_cost = round(total_cost, 2)
-    return single_result
 
 
 if __name__ == "__main__":

--- a/aws/spot-instances/run2/test_optimize.py
+++ b/aws/spot-instances/run2/test_optimize.py
@@ -4,14 +4,15 @@
 # pip install scipy
 
 import argparse
-import os
 import copy
-import sys
 import math
-import scipy.optimize
+import os
 import random
-from cloudselect.main import Client
+import sys
+
 import cloudselect.utils as utils
+import scipy.optimize
+from cloudselect.main import Client
 
 here = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, here)

--- a/aws/spot-instances/run2/test_optimize.py
+++ b/aws/spot-instances/run2/test_optimize.py
@@ -215,7 +215,12 @@ class PotpourriOptimizer:
         """
         self.bounds = []
         for size in self.sizes:
-            self.bounds.append((0, self.max_instances[size]))
+            # This means we didn't get a score, which I think can happen if we ask for
+            # instances that don't exist for the zone (oops, I did this)...!
+            if size not in self.max_instances:
+                self.bounds.append((0, 0))
+            else:
+                self.bounds.append((0, self.max_instances[size]))
 
         # Save the original bounds for reset later
         self.original_bounds = copy.deepcopy(self.bounds)
@@ -270,10 +275,17 @@ class PotpourriOptimizer:
                     break
 
                 # If the score is == our risk tolerance, we are good!
-                score = score["SpotPlacementScores"][0]["Score"]
+                if not score["SpotPlacementScores"]:
+                    score = None
+                else:
+                    score = score["SpotPlacementScores"][0]["Score"]
 
                 # If we are in the risk tolerance, break from the while
-                if score >= self.min_score:
+                if score is None:
+                    print(f"Size {core} does not have a score.")
+                    break
+
+                elif score >= self.min_score:
                     print(
                         f"✅️ Spot score: size {core}     [satisfed]: {count} instances (score: {score})"
                     )

--- a/aws/spot-instances/run2/tests/512/spot-choices-us-east-1.json
+++ b/aws/spot-instances/run2/tests/512/spot-choices-us-east-1.json
@@ -1,0 +1,2094 @@
+[
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 3,
+        "total_cost": 13.27
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 14.04
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.07
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.129999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 14.219999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 14.239999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.23
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.33
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.6
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.62
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.99
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.19
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.620000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 15.95
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 15.98
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.04
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.15
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.23
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.34
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.380000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.439999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.71
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.73
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.3
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 5.09,
+                "instances_cost": 15.27,
+                "available": 3
+            }
+        ],
+        "total_count": 3,
+        "total_cost": 15.27
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 18,
+        "total_cost": 15.39
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 15.42
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.379999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 15.48
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 15.48
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 15.57
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 15.59
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 15.79
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 15.82
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 15.870000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 16.48
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 17.62
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 17.82
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 17.740000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 18,
+        "total_cost": 17.77
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.73
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 17.83
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 17.83
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 17.92
+    }
+]

--- a/aws/spot-instances/run2/tests/512/spot-choices-us-east-2.json
+++ b/aws/spot-instances/run2/tests/512/spot-choices-us-east-2.json
@@ -1,0 +1,2038 @@
+[
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 128,
+                "total_cores": 512,
+                "cost_per_instance": 3.09,
+                "instances_cost": 12.36,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 12.36
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 14.04
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.07
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.129999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 14.219999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 14.239999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.23
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.33
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.36
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.84
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.879999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 14.91
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 14.96
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 15.57
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.71
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.91
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.97
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 18.3
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 18.33
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 18.39
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.5
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.58
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 36,
+                "total_cores": 288,
+                "cost_per_instance": 1.48,
+                "instances_cost": 11.84,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 18.65
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 18.689999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 18.73
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 18.79
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 19.060000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 19.08
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 19.099999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 19.099999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 19.650000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 14.48
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 18,
+        "total_cost": 14.51
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.66
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.68
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.6
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.62
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.99
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.19
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.620000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 15.95
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 15.98
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.04
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.15
+    }
+]

--- a/aws/spot-instances/run2/tests/512/spot-choices-us-west-1.json
+++ b/aws/spot-instances/run2/tests/512/spot-choices-us-west-1.json
@@ -1,0 +1,934 @@
+[
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 20,
+        "total_cost": 20.090000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 20.12
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 20.080000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 20.18
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 20.18
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 20.270000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 20.290000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 20.450000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 20.490000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 20.520000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.57
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 21.18
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 96,
+                "total_cores": 576,
+                "cost_per_instance": 3.72,
+                "instances_cost": 22.32,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.32
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 5,
+                "size": 96,
+                "total_cores": 480,
+                "cost_per_instance": 3.72,
+                "instances_cost": 18.6,
+                "available": 10
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.520000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 20.21
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.240000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.4
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.61
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 20.619999999999997
+    },
+    {
+        "instances": [
+            {
+                "count": 9,
+                "size": 36,
+                "total_cores": 324,
+                "cost_per_instance": 1.48,
+                "instances_cost": 13.32,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 20.76
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 36,
+                "total_cores": 144,
+                "cost_per_instance": 1.48,
+                "instances_cost": 5.92,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 20.8
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 20.84
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.9
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 21.17
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 21.19
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 21.21
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.48,
+                "instances_cost": 4.4399999999999995,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 21.21
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 96,
+                "total_cores": 384,
+                "cost_per_instance": 3.72,
+                "instances_cost": 14.88,
+                "available": 10
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 21.76
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 20.439999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 6,
+                "size": 36,
+                "total_cores": 216,
+                "cost_per_instance": 1.48,
+                "instances_cost": 8.879999999999999,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 20.47
+    }
+]

--- a/aws/spot-instances/run2/tests/512/spot-choices-us-west-2.json
+++ b/aws/spot-instances/run2/tests/512/spot-choices-us-west-2.json
@@ -1,0 +1,2038 @@
+[
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 128,
+                "total_cores": 512,
+                "cost_per_instance": 3.09,
+                "instances_cost": 12.36,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 12.36
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 5.09,
+                "instances_cost": 10.18,
+                "available": 3
+            }
+        ],
+        "total_count": 3,
+        "total_cost": 13.27
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 14.04
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.07
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.129999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 14.219999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 14.239999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.23
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.33
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.36
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.84
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.879999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 14.91
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 14.96
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 15.57
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.71
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 16.91
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 16.39
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 16.42
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 16.48
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.57
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 16.59
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.58
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.68
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 16.82
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.95
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.97
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 16.990000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.990000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.72,
+                "instances_cost": 11.16,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.34
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 17.54
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.52,
+                "instances_cost": 1.52,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 14.469999999999999
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.85,
+                "instances_cost": 1.85,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.6
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.08,
+                "instances_cost": 1.08,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.62
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.58,
+                "instances_cost": 2.58,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.48,
+                "instances_cost": 1.48,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.64
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 14.99
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.92,
+                "instances_cost": 3.92,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.09,
+                "instances_cost": 6.18,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.19
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 19,
+        "total_cost": 14.48
+    },
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 18,
+        "total_cost": 14.51
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.79,
+                "instances_cost": 1.58,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 14.57
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 14.66
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 128,
+                "total_cores": 384,
+                "cost_per_instance": 3.09,
+                "instances_cost": 9.27,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 14.68
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.72,
+                "instances_cost": 7.44,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 15.620000000000001
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 15.95
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 15.98
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 16.04
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.5,
+                "instances_cost": 0.5,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.79,
+                "instances_cost": 0.79,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.48,
+                "instances_cost": 2.96,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.72,
+                "instances_cost": 3.72,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.09,
+                "instances_cost": 3.09,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 192,
+                "total_cores": 192,
+                "cost_per_instance": 5.09,
+                "instances_cost": 5.09,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 16.15
+    }
+]

--- a/aws/spot-instances/run2/tests/768/spot-choices-us-east-1.json
+++ b/aws/spot-instances/run2/tests/768/spot-choices-us-east-1.json
@@ -1,0 +1,2126 @@
+[
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 192,
+                "total_cores": 768,
+                "cost_per_instance": 4.95,
+                "instances_cost": 19.8,
+                "available": 3
+            }
+        ],
+        "total_count": 4,
+        "total_cost": 19.8
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 20.69
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 15,
+        "total_cost": 20.720000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 20.78
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 11,
+        "total_cost": 20.87
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 20.87
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 20.87
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 18,
+                "total_cores": 36,
+                "cost_per_instance": 0.78,
+                "instances_cost": 1.56,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 20.970000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 21.05
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 21.35
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 21.75
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 21.770000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 21.82
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 21.840000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 22.46
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 23.68
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.93,
+                "instances_cost": 3.93,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 2,
+                "size": 128,
+                "total_cores": 256,
+                "cost_per_instance": 3.1,
+                "instances_cost": 6.2,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 23.82
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 17,
+        "total_cost": 23.32
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 16,
+        "total_cost": 23.35
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 23.41
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 7,
+                "size": 36,
+                "total_cores": 252,
+                "cost_per_instance": 1.46,
+                "instances_cost": 10.219999999999999,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 14,
+        "total_cost": 23.419999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 4,
+                "size": 36,
+                "total_cores": 144,
+                "cost_per_instance": 1.46,
+                "instances_cost": 5.84,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 23.41
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 23.5
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 23.9
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 24.05
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 24.15
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 24.21
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 16,
+                "total_cores": 32,
+                "cost_per_instance": 1.1,
+                "instances_cost": 2.2,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 24.240000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 24.25
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 96,
+                "total_cores": 288,
+                "cost_per_instance": 3.79,
+                "instances_cost": 11.370000000000001,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 24.37
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.93,
+                "instances_cost": 3.93,
+                "available": 23
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 24.509999999999998
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 24.61
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 24,
+                "total_cores": 48,
+                "cost_per_instance": 1.53,
+                "instances_cost": 3.06,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 192,
+                "total_cores": 384,
+                "cost_per_instance": 4.95,
+                "instances_cost": 9.9,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 25.1
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 21.14
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 21.26
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 21.270000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 36,
+                "total_cores": 36,
+                "cost_per_instance": 1.46,
+                "instances_cost": 1.46,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 21.29
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 6,
+        "total_cost": 21.3
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 21.740000000000002
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 64,
+                "total_cores": 64,
+                "cost_per_instance": 3.93,
+                "instances_cost": 3.93,
+                "available": 23
+            },
+            {
+                "count": 1,
+                "size": 128,
+                "total_cores": 128,
+                "cost_per_instance": 3.1,
+                "instances_cost": 3.1,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 21.880000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 96,
+                "total_cores": 192,
+                "cost_per_instance": 3.79,
+                "instances_cost": 7.58,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 5,
+        "total_cost": 22.43
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 22.64
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 12,
+        "total_cost": 22.67
+    },
+    {
+        "instances": [
+            {
+                "count": 2,
+                "size": 1,
+                "total_cores": 2,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 10,
+        "total_cost": 22.73
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 8,
+        "total_cost": 22.82
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 5,
+                "size": 36,
+                "total_cores": 180,
+                "cost_per_instance": 1.46,
+                "instances_cost": 7.3,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 13,
+        "total_cost": 22.93
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 18,
+                "total_cores": 18,
+                "cost_per_instance": 0.78,
+                "instances_cost": 0.78,
+                "available": 3
+            },
+            {
+                "count": 5,
+                "size": 36,
+                "total_cores": 180,
+                "cost_per_instance": 1.46,
+                "instances_cost": 7.3,
+                "available": 3
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 9,
+        "total_cost": 22.93
+    },
+    {
+        "instances": [
+            {
+                "count": 3,
+                "size": 36,
+                "total_cores": 108,
+                "cost_per_instance": 1.46,
+                "instances_cost": 4.38,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 23.020000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 23.090000000000003
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 2,
+                "size": 36,
+                "total_cores": 72,
+                "cost_per_instance": 1.46,
+                "instances_cost": 2.92,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 96,
+                "total_cores": 96,
+                "cost_per_instance": 3.79,
+                "instances_cost": 3.79,
+                "available": 10
+            },
+            {
+                "count": 3,
+                "size": 192,
+                "total_cores": 576,
+                "cost_per_instance": 4.95,
+                "instances_cost": 14.850000000000001,
+                "available": 3
+            }
+        ],
+        "total_count": 7,
+        "total_cost": 23.42
+    }
+]

--- a/aws/spot-instances/run2/tests/768/spot-choices-us-east-2.json
+++ b/aws/spot-instances/run2/tests/768/spot-choices-us-east-2.json
@@ -1,0 +1,870 @@
+[
+    {
+        "instances": [
+            {
+                "count": 12,
+                "size": 1,
+                "total_cores": 12,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.6000000000000001,
+                "available": 54
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 54,
+        "total_cost": 33.36
+    },
+    {
+        "instances": [
+            {
+                "count": 10,
+                "size": 1,
+                "total_cores": 10,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.5,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 53,
+        "total_cost": 33.39
+    },
+    {
+        "instances": [
+            {
+                "count": 8,
+                "size": 1,
+                "total_cores": 8,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.4,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 51,
+        "total_cost": 33.449999999999996
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 49,
+        "total_cost": 33.54
+    },
+    {
+        "instances": [
+            {
+                "count": 4,
+                "size": 1,
+                "total_cores": 4,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.2,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 47,
+        "total_cost": 33.54
+    },
+    {
+        "instances": [
+            {
+                "count": 43,
+                "size": 18,
+                "total_cores": 774,
+                "cost_per_instance": 0.78,
+                "instances_cost": 33.54,
+                "available": 3
+            }
+        ],
+        "total_count": 43,
+        "total_cost": 33.54
+    },
+    {
+        "instances": [
+            {
+                "count": 40,
+                "size": 18,
+                "total_cores": 720,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.200000000000003,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            }
+        ],
+        "total_count": 41,
+        "total_cost": 33.77
+    },
+    {
+        "instances": [
+            {
+                "count": 6,
+                "size": 1,
+                "total_cores": 6,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.30000000000000004,
+                "available": 54
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            }
+        ],
+        "total_count": 48,
+        "total_cost": 33.81
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 43,
+        "total_cost": 33.83
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 42,
+        "total_cost": 33.84
+    },
+    {
+        "instances": [
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 42,
+                "size": 18,
+                "total_cores": 756,
+                "cost_per_instance": 0.78,
+                "instances_cost": 32.76,
+                "available": 3
+            }
+        ],
+        "total_count": 43,
+        "total_cost": 33.86
+    },
+    {
+        "instances": [
+            {
+                "count": 30,
+                "size": 1,
+                "total_cores": 30,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.5,
+                "available": 54
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 71,
+        "total_cost": 33.480000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 28,
+                "size": 1,
+                "total_cores": 28,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.4000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 70,
+        "total_cost": 33.51
+    },
+    {
+        "instances": [
+            {
+                "count": 26,
+                "size": 1,
+                "total_cores": 26,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.3,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 68,
+        "total_cost": 33.57
+    },
+    {
+        "instances": [
+            {
+                "count": 24,
+                "size": 1,
+                "total_cores": 24,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.2000000000000002,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 66,
+        "total_cost": 33.660000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 22,
+                "size": 1,
+                "total_cores": 22,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.1,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 64,
+        "total_cost": 33.660000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 14,
+                "size": 1,
+                "total_cores": 14,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.7000000000000001,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 56,
+        "total_cost": 33.78
+    },
+    {
+        "instances": [
+            {
+                "count": 16,
+                "size": 1,
+                "total_cores": 16,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.8,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 40,
+                "size": 18,
+                "total_cores": 720,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.200000000000003,
+                "available": 3
+            }
+        ],
+        "total_count": 57,
+        "total_cost": 33.86
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 41,
+                "size": 18,
+                "total_cores": 738,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.98,
+                "available": 3
+            }
+        ],
+        "total_count": 60,
+        "total_cost": 33.95
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 9,
+                "size": 2,
+                "total_cores": 18,
+                "cost_per_instance": 0.13,
+                "instances_cost": 1.17,
+                "available": 51
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 96,
+        "total_cost": 33.99
+    },
+    {
+        "instances": [
+            {
+                "count": 18,
+                "size": 1,
+                "total_cores": 18,
+                "cost_per_instance": 0.05,
+                "instances_cost": 0.9,
+                "available": 54
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 48,
+                "total_cores": 48,
+                "cost_per_instance": 2.57,
+                "instances_cost": 2.57,
+                "available": 44
+            }
+        ],
+        "total_count": 58,
+        "total_cost": 33.89
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 7,
+                "size": 2,
+                "total_cores": 14,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.91,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 4,
+                "total_cores": 4,
+                "cost_per_instance": 0.29,
+                "instances_cost": 0.29,
+                "available": 52
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 95,
+        "total_cost": 34.02
+    },
+    {
+        "instances": [
+            {
+                "count": 34,
+                "size": 1,
+                "total_cores": 34,
+                "cost_per_instance": 0.05,
+                "instances_cost": 1.7000000000000002,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 32,
+                "total_cores": 32,
+                "cost_per_instance": 1.86,
+                "instances_cost": 1.86,
+                "available": 39
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 74,
+        "total_cost": 33.980000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 5,
+                "size": 2,
+                "total_cores": 10,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.65,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 8,
+                "total_cores": 8,
+                "cost_per_instance": 0.58,
+                "instances_cost": 0.58,
+                "available": 45
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 93,
+        "total_cost": 34.050000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 16,
+                "total_cores": 16,
+                "cost_per_instance": 1.1,
+                "instances_cost": 1.1,
+                "available": 43
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 89,
+        "total_cost": 34.050000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 42,
+                "size": 1,
+                "total_cores": 42,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.1,
+                "available": 54
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            },
+            {
+                "count": 1,
+                "size": 24,
+                "total_cores": 24,
+                "cost_per_instance": 1.53,
+                "instances_cost": 1.53,
+                "available": 41
+            }
+        ],
+        "total_count": 82,
+        "total_cost": 34.050000000000004
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 6,
+                "size": 2,
+                "total_cores": 12,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.78,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 6,
+                "total_cores": 6,
+                "cost_per_instance": 0.48,
+                "instances_cost": 0.48,
+                "available": 4
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 94,
+        "total_cost": 34.080000000000005
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 3,
+                "size": 2,
+                "total_cores": 6,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.39,
+                "available": 51
+            },
+            {
+                "count": 1,
+                "size": 12,
+                "total_cores": 12,
+                "cost_per_instance": 1.07,
+                "instances_cost": 1.07,
+                "available": 7
+            },
+            {
+                "count": 39,
+                "size": 18,
+                "total_cores": 702,
+                "cost_per_instance": 0.78,
+                "instances_cost": 30.42,
+                "available": 3
+            }
+        ],
+        "total_count": 91,
+        "total_cost": 34.28
+    },
+    {
+        "instances": [
+            {
+                "count": 48,
+                "size": 1,
+                "total_cores": 48,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.4000000000000004,
+                "available": 54
+            },
+            {
+                "count": 40,
+                "size": 18,
+                "total_cores": 720,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.200000000000003,
+                "available": 3
+            }
+        ],
+        "total_count": 88,
+        "total_cost": 33.6
+    },
+    {
+        "instances": [
+            {
+                "count": 46,
+                "size": 1,
+                "total_cores": 46,
+                "cost_per_instance": 0.05,
+                "instances_cost": 2.3000000000000003,
+                "available": 54
+            },
+            {
+                "count": 1,
+                "size": 2,
+                "total_cores": 2,
+                "cost_per_instance": 0.13,
+                "instances_cost": 0.13,
+                "available": 51
+            },
+            {
+                "count": 40,
+                "size": 18,
+                "total_cores": 720,
+                "cost_per_instance": 0.78,
+                "instances_cost": 31.200000000000003,
+                "available": 3
+            }
+        ],
+        "total_count": 87,
+        "total_cost": 33.63
+    }
+]


### PR DESCRIPTION
Instead of just choosing the first by index, this approach chooses to remove the most instance size (decrement the max bound by one) for the most expensive instance type. This means in practice we tend to keep the cheaper ones (cost per core per hour) around and will run out of solutions (e.g., around 17). From the below, we see that our first 17 solutions are all better (by cost) than the first heuristic!

```console
$ python test_optimize.py 512 --results 100

☝️  Max spot price: 8.625
👇️ Min spot price: 0.0023499999999999

😸️ Filtered selection of spot:
          instance  bare_metal    arch  vcpu  cores  threads_per_core  memory_mb hypervisor    gpu  spot_price     price
659     c7a.medium       False  x86_64     1      1                 1       2048      nitro  False    0.016225   0.05132
474     m7a.medium       False  x86_64     1      1                 1       4096      nitro  False    0.026825   0.05796
279     r7a.medium       False  x86_64     1      1                 1       8192      nitro  False    0.036050   0.07608
245       t3a.nano       False  x86_64     2      1                 2        512      nitro  False    0.002350   0.00470
551        t3.nano       False  x86_64     2      1                 2        512      nitro  False    0.002520   0.00520
..             ...         ...     ...   ...    ...               ...        ...        ...    ...         ...       ...
129   r6a.48xlarge       False  x86_64   192     96                 2    1572864      nitro  False    4.527040  10.88640
611   m7a.48xlarge       False  x86_64   192    192                 1     786432      nitro  False    4.785250  11.12832
209  inf2.48xlarge       False  x86_64   192     96                 2     786432      nitro  False    4.869125  12.98127
461   r7i.48xlarge       False  x86_64   192     96                 2    1572864      nitro  False    5.225550  12.70080
391   r7a.48xlarge       False  x86_64   192    192                 1    1572864      nitro  False    6.748750  14.60640

[425 rows x 11 columns]

🤓️ Mean (std) of spot price
$1.21 ($1.36)

Getting spot score for instances of size 1
✅️ Spot score: size 1     [satisfed]: 50 instances (score: 9)
Getting spot score for instances of size 2
✅️ Spot score: size 2     [satisfed]: 50 instances (score: 9)
Getting spot score for instances of size 4
✅️ Spot score: size 4     [satisfed]: 50 instances (score: 9)
Getting spot score for instances of size 8
✅️ Spot score: size 8     [satisfed]: 50 instances (score: 9)
Getting spot score for instances of size 6
❌️ Spot score: size 6 [not-satisfed]: 50 instances (score: 3)
Getting spot score for instances of size 6
✅️ Spot score: size 6     [satisfed]: 33 instances (score: 9)
Getting spot score for instances of size 16
✅️ Spot score: size 16     [satisfed]: 32 instances (score: 9)
Getting spot score for instances of size 12
❌️ Spot score: size 12 [not-satisfed]: 43 instances (score: 3)
Getting spot score for instances of size 12
✅️ Spot score: size 12     [satisfed]: 28 instances (score: 9)
Getting spot score for instances of size 32
✅️ Spot score: size 32     [satisfed]: 16 instances (score: 9)
Getting spot score for instances of size 18
✅️ Spot score: size 18     [satisfed]: 29 instances (score: 9)
Getting spot score for instances of size 24
✅️ Spot score: size 24     [satisfed]: 22 instances (score: 9)
Getting spot score for instances of size 48
✅️ Spot score: size 48     [satisfed]: 11 instances (score: 9)
Getting spot score for instances of size 64
✅️ Spot score: size 64     [satisfed]: 8 instances (score: 9)
Getting spot score for instances of size 36
✅️ Spot score: size 36     [satisfed]: 15 instances (score: 9)
Getting spot score for instances of size 96
✅️ Spot score: size 96     [satisfed]: 6 instances (score: 9)
Getting spot score for instances of size 128
✅️ Spot score: size 128     [satisfed]: 4 instances (score: 9)
Getting spot score for instances of size 192
❌️ Spot score: size 192 [not-satisfed]: 3 instances (score: 4)
Getting spot score for instances of size 192
❌️ Spot score: size 192 [not-satisfed]: 2 instances (score: 7)
Getting spot score for instances of size 192
✅️ Spot score: size 192     [satisfed]: 1 instances (score: 9)
        message: Optimization terminated successfully. (HiGHS Status 7: Optimal)
        success: True
         status: 0
            fun: 12.379633333333333
              x: [ 0.000e+00  0.000e+00 ...  4.000e+00  0.000e+00]
            nit: -1
          lower:  residual: [ 0.000e+00  0.000e+00 ...  4.000e+00
                              0.000e+00]
                 marginals: [ 0.000e+00  0.000e+00 ...  0.000e+00
                              0.000e+00]
          upper:  residual: [ 5.000e+01  5.000e+01 ...  0.000e+00
                              1.000e+00]
                 marginals: [ 0.000e+00  0.000e+00 ...  0.000e+00
                              0.000e+00]
          eqlin:  residual: []
                 marginals: []
        ineqlin:  residual: [ 5.080e+02  0.000e+00]
                 marginals: [ 0.000e+00  0.000e+00]
 mip_node_count: 1
 mip_dual_bound: 12.379633333333333
        mip_gap: 0.0

⭐️ Suggested top request (accounting for price and spot scores):
  => Result: 💰️ $12.4 for 1 instances.

Calculating remainder of results (total 100)
  => Result: 💰️ $14.0 for 5 instances.
  => Result: 💰️ $14.1 for 6 instances.
  => Result: 💰️ $14.1 for 6 instances.
  => Result: 💰️ $14.2 for 6 instances.
  => Result: 💰️ $14.2 for 6 instances.
  => Result: 💰️ $14.2 for 3 instances.
  => Result: 💰️ $14.3 for 4 instances.
  => Result: 💰️ $14.4 for 2 instances.
  => Result: 💰️ $14.5 for 3 instances.
  => Result: 💰️ $14.8 for 3 instances.
  => Result: 💰️ $14.9 for 4 instances.
  => Result: 💰️ $14.9 for 4 instances.
  => Result: 💰️ $15.0 for 5 instances.
  => Result: 💰️ $15.6 for 3 instances.
  => Result: 💰️ $16.7 for 2 instances.
  => Result: 💰️ $16.9 for 3 instances.
Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest.
Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest.
  => Result: 💰️ $20.1 for 3 instances.
  => Result: 💰️ $20.1 for 4 instances.
  => Result: 💰️ $20.1 for 2 instances.
  => Result: 💰️ $20.2 for 4 instances.
  => Result: 💰️ $20.2 for 2 instances.
  => Result: 💰️ $20.3 for 4 instances.
  => Result: 💰️ $20.3 for 4 instances.
  => Result: 💰️ $20.5 for 2 instances.
  => Result: 💰️ $20.5 for 3 instances.
  => Result: 💰️ $20.5 for 3 instances.
  => Result: 💰️ $20.6 for 4 instances.
  => Result: 💰️ $21.2 for 2 instances.
  => Result: 💰️ $22.3 for 1 instances.
  => Result: 💰️ $22.5 for 2 instances.
Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest.
Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest.
Hit unsuccessful result, likely out of solutions. Allowing adjust of cheapest.
Likely hit local solution, exiting!
Saving results to spot-instance-choices.json
```

The issue I ran into was some sort of local min/max, meaning we had removed all the max cost per core (by max bounds) and then couldn't find a solution. I tried a bit of a hack approach to allow removing a lower cost instance, but in practice I think we should actually just choose one at random. I'm opening a PR to show the changes! I also turned it into an overloaded class, PotpourriOptimizer and named the instance "poo" because there is no other way! :hankey: 

For direct comparison, the top set before:

```console
⭐️ Suggested top request (accounting for price and spot scores):
  => Result: 💰️ $12.4 for 1 instances.

Calculating remainder of results (total {args.results})
  => Result: 💰️ $14.0 for 5 instances.
  => Result: 💰️ $16.4 for 5 instances.
  => Result: 💰️ $18.0 for 2 instances.
  => Result: 💰️ $20.2 for 4 instances.
  => Result: 💰️ $20.4 for 3 instances.
  => Result: 💰️ $20.8 for 4 instances.
  => Result: 💰️ $21.0 for 4 instances.
  => Result: 💰️ $21.1 for 4 instances.
  => Result: 💰️ $21.6 for 3 instances.
  => Result: 💰️ $21.7 for 3 instances.
  => Result: 💰️ $21.8 for 3 instances.
```
And after:

```console
⭐️ Suggested top request (accounting for price and spot scores):
  => Result: 💰️ $12.4 for 1 instances.

Calculating remainder of results (total 100)
  => Result: 💰️ $14.0 for 5 instances.
  => Result: 💰️ $14.1 for 6 instances.
  => Result: 💰️ $14.1 for 6 instances.
  => Result: 💰️ $14.2 for 6 instances.
  => Result: 💰️ $14.2 for 6 instances.
  => Result: 💰️ $14.2 for 3 instances.
  => Result: 💰️ $14.3 for 4 instances.
  => Result: 💰️ $14.4 for 2 instances.
  => Result: 💰️ $14.5 for 3 instances.
  => Result: 💰️ $14.8 for 3 instances.
  => Result: 💰️ $14.9 for 4 instances.
  => Result: 💰️ $14.9 for 4 instances.
  => Result: 💰️ $15.0 for 5 instances.
  => Result: 💰️ $15.6 for 3 instances.
  => Result: 💰️ $16.7 for 2 instances.
  => Result: 💰️ $16.9 for 3 instances.
```
An improvement, but again I'd like the second half of the above (shown in the top output) to be randomly chosen. We can chat more about this I hope!